### PR TITLE
api: accept workflow specifications instead of toplevel+workflow name

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -97,13 +97,13 @@
         "summary": "Returns all workflows."
       }
     },
-    "/api/yadage_from_remote": {
+    "/api/yadage/remote": {
       "post": {
         "consumes": [
           "application/json"
         ],
         "description": "This resource is expecting JSON data with all the necessary information to instantiate a yadage workflow from a remote repository.",
-        "operationId": "create_yadage_workflow_from_remote",
+        "operationId": "run_yadage_workflow_from_remote",
         "parameters": [
           {
             "description": "Required. Organization which the worklow belongs to.",
@@ -177,13 +177,13 @@
         "summary": "Creates a new yadage workflow from a remote repository."
       }
     },
-    "/api/yadage_from_spec": {
+    "/api/yadage/spec": {
       "post": {
         "consumes": [
           "application/json"
         ],
         "description": "This resource is expecting a JSON yadage specification.",
-        "operationId": "create_yadage_workflow_from_spec",
+        "operationId": "run_yadage_workflow_from_spec",
         "parameters": [
           {
             "description": "Required. Organization which the worklow belongs to.",
@@ -207,15 +207,7 @@
             "schema": {
               "properties": {
                 "parameters": {
-                  "properties": {
-                    "nparallel": {
-                      "type": "integer"
-                    },
-                    "preset_pars": {
-                      "description": "Workflow parameters.",
-                      "type": "object"
-                    }
-                  },
+                  "description": "Workflow parameters.",
                   "type": "object"
                 },
                 "workflow_spec": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -97,13 +97,13 @@
         "summary": "Returns all workflows."
       }
     },
-    "/api/yadage": {
+    "/api/yadage_from_remote": {
       "post": {
         "consumes": [
           "application/json"
         ],
-        "description": "This resource is expecting JSON data with all the necessary informations to instantiate a yadage workflow.",
-        "operationId": "create_yadage_workflow",
+        "description": "This resource is expecting JSON data with all the necessary information to instantiate a yadage workflow from a remote repository.",
+        "operationId": "create_yadage_workflow_from_remote",
         "parameters": [
           {
             "description": "Required. Organization which the worklow belongs to.",
@@ -120,9 +120,9 @@
             "type": "string"
           },
           {
-            "description": "Specification with necessary data to instantiate a yadage workflow.",
+            "description": "Workflow information in JSON format with all the necessary data to instantiate a yadage workflow from a remote repository such as GitHub.",
             "in": "body",
-            "name": "yadage_payload",
+            "name": "workflow_data",
             "required": true,
             "schema": {
               "properties": {
@@ -130,12 +130,15 @@
                   "type": "integer"
                 },
                 "preset_pars": {
+                  "description": "Workflow parameters.",
                   "type": "object"
                 },
                 "toplevel": {
+                  "description": "Yadage toplevel argument. It represents the remote repository where the workflow should be pulled from.",
                   "type": "string"
                 },
                 "workflow": {
+                  "description": "Yadage workflow parameter. It represents the name of the workflow spec file name inside the remote repository.",
                   "type": "string"
                 }
               },
@@ -171,7 +174,88 @@
             "description": "Request failed. The incoming data specification seems malformed"
           }
         },
-        "summary": "Creates a new yadage workflow."
+        "summary": "Creates a new yadage workflow from a remote repository."
+      }
+    },
+    "/api/yadage_from_spec": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "This resource is expecting a JSON yadage specification.",
+        "operationId": "create_yadage_workflow_from_spec",
+        "parameters": [
+          {
+            "description": "Required. Organization which the worklow belongs to.",
+            "in": "query",
+            "name": "organization",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "JSON object including workflow parameters and workflow specification in JSON format (`yadageschemas.load()` output) with necessary data to instantiate a yadage workflow.",
+            "in": "body",
+            "name": "workflow",
+            "required": true,
+            "schema": {
+              "properties": {
+                "parameters": {
+                  "properties": {
+                    "nparallel": {
+                      "type": "integer"
+                    },
+                    "preset_pars": {
+                      "description": "Workflow parameters.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "workflow_spec": {
+                  "description": "Yadage specification in JSON format.",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The workflow has been instantiated.",
+            "examples": {
+              "application/json": {
+                "message": "Workflow successfully launched",
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed"
+          }
+        },
+        "summary": "Creates a new yadage workflow from a specification file."
       }
     }
   },

--- a/reana_workflow_controller/rest.py
+++ b/reana_workflow_controller/rest.py
@@ -147,8 +147,8 @@ def get_workflows():  # noqa
         return jsonify({"message": str(e)}), 500
 
 
-@restapi_blueprint.route('/yadage_from_remote', methods=['POST'])
-def yadage_endpoint():  # noqa
+@restapi_blueprint.route('/yadage/remote', methods=['POST'])
+def run_yadage_workflow_from_remote_endpoint():  # noqa
     r"""Create a new yadage workflow from a remote repository.
 
     ---
@@ -157,7 +157,7 @@ def yadage_endpoint():  # noqa
       description: >-
         This resource is expecting JSON data with all the necessary information
         to instantiate a yadage workflow from a remote repository.
-      operationId: create_yadage_workflow_from_remote
+      operationId: run_yadage_workflow_from_remote
       consumes:
         - application/json
       produces:
@@ -234,15 +234,15 @@ def yadage_endpoint():  # noqa
         abort(400)
 
 
-@restapi_blueprint.route('/yadage_from_spec', methods=['POST'])
-def yadage_from_spec_endpoint():  # noqa
+@restapi_blueprint.route('/yadage/spec', methods=['POST'])
+def run_yadage_workflow_from_spec_endpoint():  # noqa
     r"""Create a new yadage workflow.
 
     ---
     post:
       summary: Creates a new yadage workflow from a specification file.
       description: This resource is expecting a JSON yadage specification.
-      operationId: create_yadage_workflow_from_spec
+      operationId: run_yadage_workflow_from_spec
       consumes:
         - application/json
       produces:
@@ -270,12 +270,7 @@ def yadage_from_spec_endpoint():  # noqa
             properties:
               parameters:
                 type: object
-                properties:
-                  nparallel:
-                    type: integer
-                  preset_pars:
-                    type: object
-                    description: Workflow parameters.
+                description: Workflow parameters.
               workflow_spec:
                 type: object
                 description: >-
@@ -302,12 +297,14 @@ def yadage_from_spec_endpoint():  # noqa
             Request failed. The incoming data specification seems malformed
     """
     try:
+        # hardcoded until confirmation from `yadage`
+        nparallel = 10
         if request.json:
             arguments = {
-                "nparallel": request.json['parameters']['nparallel'],
+                "nparallel": nparallel,
                 "workflow": request.json['workflow_spec'],
                 "toplevel": "",  # ignored when spec submited
-                "preset_pars": request.json['parameters']['preset_pars']
+                "preset_pars": request.json['parameters']
             }
             queue = organization_to_queue[request.args.get('organization')]
             resultobject = run_yadage_workflow.apply_async(


### PR DESCRIPTION
Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>