### PR TITLE
api: fix path to write input files

### DIFF
--- a/reana_workflow_controller/rest.py
+++ b/reana_workflow_controller/rest.py
@@ -348,7 +348,8 @@ def seed_workflow_workspace(workflow_id):
             raise ValueError('The file transferred needs to have name.')
 
         workflow = Workflow.query.filter(Workflow.id_ == workflow_id).first()
-        file_.save(os.path.join(workflow.workspace, file_name))
+        file_.save(os.path.join(os.getenv('SHARED_VOLUME_PATH'),
+                                workflow.workspace_path, file_name))
         return jsonify({'message': 'File successfully transferred'}), 200
     except KeyError as e:
         return jsonify({"message": str(e)}), 400


### PR DESCRIPTION
* (closes reanahub/reana-server#13).

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>