### PR TITLE
api: add endpoint to retrieve output files

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -262,6 +262,73 @@
         "summary": "Adds a file to the workflow workspace."
       }
     },
+    "/api/workflows/{workflow_id}/workspace/outputs/{file_name}": {
+      "get": {
+        "description": "This resource is expecting a workflow UUID and a filename to return its content.",
+        "operationId": "get_workflow_outputs_file",
+        "parameters": [
+          {
+            "description": "Required. Organization which the worklow belongs to.",
+            "in": "query",
+            "name": "organization",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Workflow UUID.",
+            "in": "path",
+            "name": "workflow_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Name (or path) of the file to be downloaded.",
+            "in": "path",
+            "name": "file_name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "multipart/form-data"
+        ],
+        "responses": {
+          "200": {
+            "description": "Requests succeeded. The file has been downloaded.",
+            "schema": {
+              "type": "file"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed."
+          },
+          "404": {
+            "description": "Request failed. User doesn't exist.",
+            "examples": {
+              "application/json": {
+                "message": "User 00000000-0000-0000-0000-000000000000 doesn't exist"
+              }
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error.",
+            "examples": {
+              "application/json": {
+                "message": "Either organization or user doesn't exist."
+              }
+            }
+          }
+        },
+        "summary": "Returns the requested file."
+      }
+    },
     "/api/yadage/remote": {
       "post": {
         "consumes": [

--- a/reana_workflow_controller/fsdb.py
+++ b/reana_workflow_controller/fsdb.py
@@ -25,19 +25,6 @@ from flask import current_app as app
 from fs import open_fs, path
 
 
-class REANAFS(object):
-    """REANA file system object."""
-
-    __instance = None
-
-    def __new__(cls):
-        """REANA file system object creation."""
-        if REANAFS.__instance is None:
-            with app.app_context():
-                REANAFS.__instance = open_fs(app.config['SHARED_VOLUME_PATH'])
-        return REANAFS.__instance
-
-
 def get_user_analyses_dir(org, user):
     """Build the analyses directory path for certain user and organization.
 
@@ -50,7 +37,7 @@ def get_user_analyses_dir(org, user):
 
 def create_user_space(user_id, org):
     """Create analyses directory for `user_id`."""
-    reana_fs = REANAFS()
+    reana_fs = open_fs(app.config['SHARED_VOLUME_PATH'])
     user_analyses_dir = get_user_analyses_dir(org, user_id)
     if not reana_fs.exists(user_analyses_dir):
         reana_fs.makedirs(user_analyses_dir)
@@ -68,7 +55,7 @@ def create_workflow_workspace(org, user, workflow_uuid):
     :param workflow_uuid: Analysis UUID.
     :return: Workflow and analysis workspace path.
     """
-    reana_fs = REANAFS()
+    reana_fs = open_fs(app.config['SHARED_VOLUME_PATH'])
     analysis_workspace = path.join(get_user_analyses_dir(org, user),
                                    workflow_uuid)
 


### PR DESCRIPTION
* Removes REANAFS singleton since it was making tests complicated.

* (addresses #38).

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>