### PR TITLE
api: support specifying workflow run name

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -65,7 +65,8 @@
             "examples": {
               "application/json": {
                 "message": "Workflow successfully launched",
-                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -74,6 +75,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -117,24 +121,28 @@
               "application/json": [
                 {
                   "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                  "name": "mytest-1",
                   "organization": "default_org",
                   "status": "running",
                   "user": "00000000-0000-0000-0000-000000000000"
                 },
                 {
                   "id": "3c9b117c-d40a-49e3-a6de-5f89fcada5a3",
+                  "name": "mytest-2",
                   "organization": "default_org",
                   "status": "finished",
                   "user": "00000000-0000-0000-0000-000000000000"
                 },
                 {
                   "id": "72e3ee4f-9cd3-4dc7-906c-24511d9f5ee3",
+                  "name": "mytest-3",
                   "organization": "default_org",
                   "status": "waiting",
                   "user": "00000000-0000-0000-0000-000000000000"
                 },
                 {
                   "id": "c4c0a1a6-beef-46c7-be04-bf4b3beca5a1",
+                  "name": "mytest-4",
                   "organization": "default_org",
                   "status": "waiting",
                   "user": "00000000-0000-0000-0000-000000000000"
@@ -145,6 +153,9 @@
               "items": {
                 "properties": {
                   "id": {
+                    "type": "string"
+                  },
+                  "name": {
                     "type": "string"
                   },
                   "organization": {
@@ -209,6 +220,10 @@
             "required": true,
             "schema": {
               "properties": {
+                "name": {
+                  "description": "Workflow name. If empty name will be generated.",
+                  "type": "string"
+                },
                 "parameters": {
                   "description": "Workflow parameters.",
                   "type": "object"
@@ -235,7 +250,8 @@
             "examples": {
               "application/json": {
                 "message": "Workflow workspace has been created.",
-                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -244,6 +260,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -265,7 +284,7 @@
         "summary": "Create workflow and its workspace."
       }
     },
-    "/api/workflows/{workflow_id}/logs": {
+    "/api/workflows/{workflow_id_or_name}/logs": {
       "get": {
         "description": "This resource is expecting a workflow UUID and a filename to return its outputs.",
         "operationId": "get_workflow_logs",
@@ -285,9 +304,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name.",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           }
@@ -303,14 +322,12 @@
                 "logs": "<Workflow engine log output>",
                 "organization": "default_org",
                 "user": "00000000-0000-0000-0000-000000000000",
-                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1"
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
               "properties": {
-                "id": {
-                  "type": "string"
-                },
                 "logs": {
                   "type": "string"
                 },
@@ -318,6 +335,12 @@
                   "type": "string"
                 },
                 "user": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -347,7 +370,7 @@
         "summary": "Returns logs of a specific workflow from a workflow engine."
       }
     },
-    "/api/workflows/{workflow_id}/status": {
+    "/api/workflows/{workflow_id_or_name}/status": {
       "get": {
         "description": "This resource reports the status of workflow.",
         "operationId": "get_workflow_status",
@@ -367,9 +390,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name.",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           }
@@ -383,6 +406,7 @@
             "examples": {
               "application/json": {
                 "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "name": "mytest-1",
                 "organization": "default_org",
                 "status": "running",
                 "user": "00000000-0000-0000-0000-000000000000"
@@ -391,6 +415,9 @@
             "schema": {
               "properties": {
                 "id": {
+                  "type": "string"
+                },
+                "name": {
                   "type": "string"
                 },
                 "organization": {
@@ -455,9 +482,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name.",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           },
@@ -484,7 +511,8 @@
                 "organization": "default_org",
                 "status": "running",
                 "user": "00000000-0000-0000-0000-000000000000",
-                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1"
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -502,6 +530,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -555,7 +586,7 @@
         "summary": "Set workflow status."
       }
     },
-    "/api/workflows/{workflow_id}/workspace": {
+    "/api/workflows/{workflow_id_or_name}/workspace": {
       "get": {
         "description": "This resource is expecting a workflow UUID and a filename to return its list of code|input|output files.",
         "operationId": "get_workflow_files",
@@ -575,9 +606,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name.",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           },
@@ -658,9 +689,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name.",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           },
@@ -701,9 +732,6 @@
               "properties": {
                 "message": {
                   "type": "string"
-                },
-                "workflow_id": {
-                  "type": "string"
                 }
               },
               "type": "object"
@@ -735,7 +763,7 @@
         "summary": "Adds a file to the workflow workspace."
       }
     },
-    "/api/workflows/{workflow_id}/workspace/outputs/{file_name}": {
+    "/api/workflows/{workflow_id_or_name}/workspace/outputs/{file_name}": {
       "get": {
         "description": "This resource is expecting a workflow UUID and a filename to return its content.",
         "operationId": "get_workflow_outputs_file",
@@ -755,9 +783,9 @@
             "type": "string"
           },
           {
-            "description": "Required. Workflow UUID.",
+            "description": "Required. Workflow UUID or name",
             "in": "path",
-            "name": "workflow_id",
+            "name": "workflow_id_or_name",
             "required": true,
             "type": "string"
           },
@@ -860,7 +888,8 @@
             "examples": {
               "application/json": {
                 "message": "Workflow successfully launched",
-                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -869,6 +898,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },
@@ -933,7 +965,8 @@
             "examples": {
               "application/json": {
                 "message": "Workflow successfully launched",
-                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac"
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest-1"
               }
             },
             "schema": {
@@ -942,6 +975,9 @@
                   "type": "string"
                 },
                 "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
                   "type": "string"
                 }
               },

--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -58,3 +58,8 @@ ALLOWED_LIST_DIRECTORIES = {'input': INPUTS_RELATIVE_PATH,
                             'code': CODE_RELATIVE_PATH,
                             'output': OUTPUTS_RELATIVE_PATH}
 """Directories allowed to be listed."""
+
+DEFAULT_NAME_FOR_WORKFLOWS = 'workflow'
+"""The default prefix used to name workflow(s): e.g. reana-1, reana-2, etc.
+   If workflow is manually named by the user that prefix will used instead.
+"""

--- a/reana_workflow_controller/errors.py
+++ b/reana_workflow_controller/errors.py
@@ -23,5 +23,13 @@
 """REANA Workflow Controller errors."""
 
 
+class WorkflowNameError(Exception):
+    """."""
+
+
+class WorkflowInexistentError(Exception):
+    """."""
+
+
 class REANAWorkflowControllerError(Exception):
     """Error when trying to manage workflows."""

--- a/reana_workflow_controller/models.py
+++ b/reana_workflow_controller/models.py
@@ -64,7 +64,9 @@ class WorkflowStatus(enum.Enum):
 class Workflow(db.Model):
     """Workflow model."""
 
-    id_ = db.Column(UUIDType, primary_key=True)
+    id_ = db.Column(UUIDType, unique=True)
+    name = db.Column(db.String(255))
+    run_number = db.Column(db.Integer, primary_key=True, autoincrement="auto")
     create_date = db.Column(db.DateTime, default=db.func.now())
     workspace_path = db.Column(db.String(255))
     status = db.Column(db.Enum(WorkflowStatus), default=WorkflowStatus.created)
@@ -74,11 +76,12 @@ class Workflow(db.Model):
     type_ = db.Column(db.String(30))
     logs = db.Column(db.String, default="")
 
-    def __init__(self, id_, workspace_path, owner_id,
+    def __init__(self, id_, name, workspace_path, owner_id,
                  specification, parameters, type_,
                  status=WorkflowStatus.created):
         """Initialize workflow model."""
         self.id_ = id_
+        self.name = name
         self.workspace_path = workspace_path
         self.owner_id = owner_id
         self.specification = specification

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,3 +84,43 @@ def db_session():
     """DB fixture"""
     yield db.session
     db.session.close()
+
+
+@pytest.fixture()
+def cwl_workflow_with_name():
+    return {'parameters': {'min_year': '1991',
+                           'max_year': '2001'},
+            'specification': {'first': 'do this',
+                              'second': 'do that'},
+            'type': 'cwl',
+            'name': 'my_test_workflow'}
+
+
+@pytest.fixture()
+def yadage_workflow_with_name():
+    return {'parameters': {'min_year': '1991',
+                           'max_year': '2001'},
+            'specification': {'first': 'do this',
+                              'second': 'do that'},
+            'type': 'yadage',
+            'name': 'my_test_workflow'}
+
+
+@pytest.fixture()
+def cwl_workflow_without_name():
+    return {'parameters': {'min_year': '1991',
+                           'max_year': '2001'},
+            'specification': {'first': 'do this',
+                              'second': 'do that'},
+            'type': 'cwl',
+            'name': ''}
+
+
+@pytest.fixture()
+def yadage_workflow_without_name():
+    return {'parameters': {'min_year': '1991',
+                           'max_year': '2001'},
+            'specification': {'first': 'do this',
+                              'second': 'do that'},
+            'type': 'yadage',
+            'name': ''}


### PR DESCRIPTION
* Add support for specifying a name for workflow run
  (closes reanahub/reana-client#70)

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>