### PR TITLE
docker: disable uwsgi file wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,6 @@ ENV TERM=xterm
 CMD uwsgi --module reana_workflow_controller.app:app \
     --http-socket 0.0.0.0:5000 --master \
     --processes ${UWSGI_PROCESSES} --threads ${UWSGI_THREADS} \
-    --stats /tmp/stats.socket
+    --stats /tmp/stats.socket \
+    --wsgi-disable-file-wrapper
+


### PR DESCRIPTION
* Adds `--wsgi-disable-file-wrapper` flag since send_file and hence
  send_fron_directory do not work with `uwsgi` file wrapper (known
  issue https://github.com/unbit/uwsgi/issues/1126).