### PR TITLE
rest: unify inputs/outputs/code to single dir

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -739,13 +739,6 @@
             "name": "file_name",
             "required": true,
             "type": "string"
-          },
-          {
-            "description": "Required. If set to `input`, the file will be placed under `workspace/inputs/` whereas if it is of type `code` it will live under `workspace/code/`. By default it set to `input`.",
-            "in": "query",
-            "name": "file_type",
-            "required": false,
-            "type": "string"
           }
         ],
         "produces": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -619,8 +619,8 @@
     },
     "/api/workflows/{workflow_id_or_name}/workspace": {
       "get": {
-        "description": "This resource is expecting a workflow UUID and a filename to return its list of code|input|output files.",
-        "operationId": "get_workflow_files",
+        "description": "This resource is expecting a workflow run UUID which workspace file list will be retrieved.",
+        "operationId": "list_workflow_files",
         "parameters": [
           {
             "description": "Required. Organization which the worklow belongs to.",
@@ -641,13 +641,6 @@
             "in": "path",
             "name": "workflow_id_or_name",
             "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Required. The file will be retrieved from the corresponding directory `workspace/<file_type>`. Possible values are `code`, `input` and `output`. `input` is the default value.",
-            "in": "query",
-            "name": "file_type",
-            "required": false,
             "type": "string"
           }
         ],
@@ -696,7 +689,7 @@
             }
           }
         },
-        "summary": "Returns the list of code|input|output files for a specific workflow."
+        "summary": "Returns the file list for a specific workflow run workspace."
       },
       "post": {
         "consumes": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -217,7 +217,7 @@
         "summary": "Returns all workflows."
       },
       "post": {
-        "description": "This resource expects a POST call to create a new workflow workspace.",
+        "description": "This resource expects all necessary data to represent a workflow so it is stored in database and its workspace is created.",
         "operationId": "create_workflow",
         "parameters": [
           {
@@ -619,8 +619,8 @@
     },
     "/api/workflows/{workflow_id_or_name}/workspace": {
       "get": {
-        "description": "This resource is expecting a workflow run UUID which workspace file list will be retrieved.",
-        "operationId": "list_workflow_files",
+        "description": "This resource retrieves the file list of a workspace, given its workflow UUID.",
+        "operationId": "get_files",
         "parameters": [
           {
             "description": "Required. Organization which the worklow belongs to.",
@@ -689,14 +689,14 @@
             }
           }
         },
-        "summary": "Returns the file list for a specific workflow run workspace."
+        "summary": "Returns the workspace file list."
       },
       "post": {
         "consumes": [
           "multipart/form-data"
         ],
-        "description": "This resource is expecting a workflow UUID and a file to place in the workflow workspace.",
-        "operationId": "seed_workflow_files",
+        "description": "This resource is expecting a workflow UUID and a file to place in the workspace.",
+        "operationId": "upload_file",
         "parameters": [
           {
             "description": "Required. Organization which the worklow belongs to.",
@@ -720,7 +720,7 @@
             "type": "string"
           },
           {
-            "description": "Required. File to add to the workflow workspace.",
+            "description": "Required. File to add to the workspace.",
             "in": "formData",
             "name": "file_content",
             "required": true,
@@ -742,7 +742,7 @@
             "description": "Request succeeded. The file has been added to the workspace.",
             "examples": {
               "application/json": {
-                "message": "input.csv has been successfully transferred."
+                "message": "`file_name` has been successfully uploaded."
               }
             },
             "schema": {
@@ -777,13 +777,13 @@
             "description": "Request failed. Internal controller error."
           }
         },
-        "summary": "Adds a file to the workflow workspace."
+        "summary": "Adds a file to the workspace."
       }
     },
     "/api/workflows/{workflow_id_or_name}/workspace/{file_name}": {
       "get": {
-        "description": "This resource is expecting a workflow UUID and a filename to return its content.",
-        "operationId": "get_workflow_workspace_file",
+        "description": "This resource is expecting a workflow UUID and a filename existing inside the workspace to return its content.",
+        "operationId": "download_file",
         "parameters": [
           {
             "description": "Required. Organization which the worklow belongs to.",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -787,10 +787,10 @@
         "summary": "Adds a file to the workflow workspace."
       }
     },
-    "/api/workflows/{workflow_id_or_name}/workspace/outputs/{file_name}": {
+    "/api/workflows/{workflow_id_or_name}/workspace/{file_name}": {
       "get": {
         "description": "This resource is expecting a workflow UUID and a filename to return its content.",
-        "operationId": "get_workflow_outputs_file",
+        "operationId": "get_workflow_workspace_file",
         "parameters": [
           {
             "description": "Required. Organization which the worklow belongs to.",

--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -43,24 +43,6 @@ SHARED_VOLUME_PATH = os.getenv('SHARED_VOLUME_PATH', '/reana')
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 """Track modifications flag."""
 
-INPUTS_RELATIVE_PATH = 'inputs'
-"""Inputs directory name."""
-
-OUTPUTS_RELATIVE_PATH = 'outputs'
-"""Outputs directory name."""
-
-CODE_RELATIVE_PATH = 'code'
-"""Code directory name."""
-
-ALLOWED_SEED_DIRECTORIES = {'input': INPUTS_RELATIVE_PATH,
-                            'code': CODE_RELATIVE_PATH}
-"""Directories allowed to be seeded."""
-
-ALLOWED_LIST_DIRECTORIES = {'input': INPUTS_RELATIVE_PATH,
-                            'code': CODE_RELATIVE_PATH,
-                            'output': OUTPUTS_RELATIVE_PATH}
-"""Directories allowed to be listed."""
-
 DEFAULT_NAME_FOR_WORKFLOWS = 'workflow'
 """The default prefix used to name workflow(s): e.g. reana-1, reana-2, etc.
    If workflow is manually named by the user that prefix will used instead.

--- a/reana_workflow_controller/rest.py
+++ b/reana_workflow_controller/rest.py
@@ -546,16 +546,15 @@ def get_workflow_workspace_file(workflow_id_or_name, file_name):  # noqa
 @restapi_blueprint.route('/workflows/<workflow_id_or_name>/workspace',
                          methods=['GET'])
 def get_workflow_files(workflow_id_or_name):  # noqa
-    r"""List all workflow code/input/output files.
+    r"""List all files contained in a workflow run workspace.
 
     ---
     get:
-      summary: Returns the list of code|input|output files for a specific
-               workflow.
+      summary: Returns the file list for a specific workflow run workspace.
       description: >-
-        This resource is expecting a workflow UUID and a filename to return
-        its list of code|input|output files.
-      operationId: get_workflow_files
+        This resource is expecting a workflow run UUID which workspace file
+        list will be retrieved.
+      operationId: list_workflow_files
       produces:
         - multipart/form-data
       parameters:
@@ -573,14 +572,6 @@ def get_workflow_files(workflow_id_or_name):  # noqa
           in: path
           description: Required. Workflow UUID or name.
           required: true
-          type: string
-        - name: file_type
-          in: query
-          description: Required. The file will be retrieved from the
-                       corresponding directory `workspace/<file_type>`.
-                       Possible values are `code`, `input` and `output`.
-                       `input` is the default value.
-          required: false
           type: string
       responses:
         200:
@@ -634,7 +625,7 @@ def get_workflow_files(workflow_id_or_name):  # noqa
                                                    user_uuid)
 
         file_list = list_directory_files(
-            get_workflow_files_dir(workflow, file_type))
+          workflow.get_workflow_run_workspace())
         return jsonify(file_list), 200
 
     except WorkflowInexistentError:

--- a/reana_workflow_controller/rest.py
+++ b/reana_workflow_controller/rest.py
@@ -26,7 +26,8 @@ import os
 import traceback
 from uuid import UUID, uuid4
 
-from flask import Blueprint, abort, jsonify, request, send_from_directory
+from flask import (Blueprint, abort, current_app, jsonify, request,
+                   send_from_directory)
 from reana_commons.database import Session
 from reana_commons.models import (Job, Run, RunJobs, User, UserOrganization,
                                   Workflow, WorkflowStatus)
@@ -1402,14 +1403,9 @@ def start_workflow(organization, workflow):
 def run_yadage_workflow_from_spec(organization, workflow):
     """Run a yadage workflow."""
     try:
-        # Remove organization from workspace path since workflow
-        # engines already work in its organization folder.
-        workspace_path_without_organization = \
-            '/'.join(
-              workflow.get_workspace().strip('/').split('/')[1:])
         kwargs = {
             "workflow_uuid": str(workflow.id_),
-            "workflow_workspace": workspace_path_without_organization,
+            "workflow_workspace": workflow.get_workspace(),
             "workflow_json": workflow.specification,
             "parameters": workflow.parameters
         }
@@ -1462,14 +1458,9 @@ def run_cwl_workflow_from_spec_endpoint(organization, workflow):  # noqa
 def run_serial_workflow_from_spec(organization, workflow):
     """Run a serial workflow."""
     try:
-        # Remove organization from workspace path since workflow
-        # engines already work in its organization folder.
-        workspace_path_without_organization = \
-            '/'.join(
-              workflow.get_workspace().strip('/').split('/')[1:])
         kwargs = {
             "workflow_uuid": str(workflow.id_),
-            "workflow_workspace": workspace_path_without_organization,
+            "workflow_workspace": workflow.get_workspace(),
             "workflow_json": workflow.specification,
             "parameters": workflow.parameters
         }

--- a/reana_workflow_controller/rest.py
+++ b/reana_workflow_controller/rest.py
@@ -453,10 +453,10 @@ def seed_workflow_workspace(workflow_id_or_name):
 
 
 @restapi_blueprint.route(
-    '/workflows/<workflow_id_or_name>/workspace/outputs/<path:file_name>',
+    '/workflows/<workflow_id_or_name>/workspace/<path:file_name>',
     methods=['GET'])
-def get_workflow_outputs_file(workflow_id_or_name, file_name):  # noqa
-    r"""Get all workflows.
+def get_workflow_workspace_file(workflow_id_or_name, file_name):  # noqa
+    r"""Get a file contained in the workflow run workspace.
 
     ---
     get:
@@ -464,7 +464,7 @@ def get_workflow_outputs_file(workflow_id_or_name, file_name):  # noqa
       description: >-
         This resource is expecting a workflow UUID and a filename to return
         its content.
-      operationId: get_workflow_outputs_file
+      operationId: get_workflow_workspace_file
       produces:
         - multipart/form-data
       parameters:
@@ -523,8 +523,7 @@ def get_workflow_outputs_file(workflow_id_or_name, file_name):  # noqa
 
         workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name,
                                                    user_uuid)
-        outputs_directory = get_workflow_files_dir(workflow, 'output')
-        return send_from_directory(outputs_directory,
+        return send_from_directory(workflow.get_workflow_run_workspace(),
                                    file_name,
                                    mimetype='multipart/form-data',
                                    as_attachment=True), 200

--- a/reana_workflow_controller/tasks.py
+++ b/reana_workflow_controller/tasks.py
@@ -117,9 +117,7 @@ def _update_job_cache(msg):
     input_files = []
     if cached_job:
         file_access_times = calculate_file_access_time(
-            msg['caching_info'].
-            get('workflow_workspace').
-            replace('data', 'reana/default'))
+            msg['caching_info'].get('workflow_workspace'))
         for filename in cached_job.access_times:
             if filename in file_access_times and \
                     file_access_times[filename] > \
@@ -137,8 +135,7 @@ def _update_job_cache(msg):
     input_hash = calculate_job_input_hash(msg['caching_info']['job_spec'],
                                           msg['caching_info']['workflow_json'])
     workspace_hash = calculate_hash_of_dir(
-        msg['caching_info'].get('workflow_workspace').
-        replace('data', 'reana/default'), input_files)
+        msg['caching_info'].get('workflow_workspace'), input_files)
     if workspace_hash == -1:
         return
 

--- a/reana_workflow_controller/utils.py
+++ b/reana_workflow_controller/utils.py
@@ -26,17 +26,17 @@ import fs.path as fs_path
 from flask import current_app as app
 
 
-def create_workflow_run_workspace(workflow_run_workspace_path):
-    """Create workflow run workspace.
+def create_workflow_workspace(path):
+    """Create workflow workspace.
 
-    :param workflow_run_workspace_path: Relative path to workflow run dir.
-    :return: Workflow run workspace path.
+    :param path: Relative path to workspace directory.
+    :return: Absolute workspace path.
     """
     reana_fs = fs.open_fs(app.config['SHARED_VOLUME_PATH'])
-    if not reana_fs.exists(workflow_run_workspace_path):
-        reana_fs.makedirs(workflow_run_workspace_path)
+    if not reana_fs.exists(path):
+        reana_fs.makedirs(path)
 
-    return workflow_run_workspace_path
+    return path
 
 
 def list_directory_files(directory):


### PR DESCRIPTION
* Seed workflow run workspace instead per type (inputs/outputs/code).

Closes #107.
Depends on https://github.com/reanahub/reana-commons/pull/28.