### PR TITLE
tasks: split workflow params from engine params

### DIFF
--- a/reana_workflow_controller/rest.py
+++ b/reana_workflow_controller/rest.py
@@ -1357,14 +1357,15 @@ def run_cwl_workflow_from_spec_endpoint(workflow):  # noqa
         abort(400)
 
 
-def run_serial_workflow_from_spec(workflow, parameters):
+def run_serial_workflow_from_spec(workflow, engine_parameters):
     """Run a serial workflow."""
     try:
         kwargs = {
             "workflow_uuid": str(workflow.id_),
             "workflow_workspace": workflow.get_workspace(),
             "workflow_json": workflow.specification,
-            "parameters": {**workflow.parameters, **parameters},
+            "workflow_parameters": workflow.parameters,
+            "engine_parameters": engine_parameters,
         }
         if not os.environ.get("TESTS"):
             resultobject = run_serial_workflow.apply_async(


### PR DESCRIPTION
* Since we are interpolating user provided commands with their
  parameters (expanding any occurrence of $varname or ${varname}
  with the values provided as workflow parameters, we can not
  mix workflow params, those to be populated into the commands,
  and engine parameters, those to be passed to the engines to behave
  is supported and checked for correctness.
  differently (closes reanahub/reana-workflow-engine-serial#34).