### PR TITLE
tests: celery task mocking

### DIFF
--- a/reana_workflow_controller/rest.py
+++ b/reana_workflow_controller/rest.py
@@ -1286,11 +1286,10 @@ def run_yadage_workflow_from_spec(workflow):
             "workflow_json": workflow.get_specification(),
             "parameters": workflow.get_parameters()
         }
-        if not os.environ.get("TESTS"):
-            resultobject = run_yadage_workflow.apply_async(
-                kwargs=kwargs,
-                queue=WORKFLOW_QUEUES['yadage']
-            )
+        resultobject = run_yadage_workflow.apply_async(
+            kwargs=kwargs,
+            queue=WORKFLOW_QUEUES['yadage']
+        )
         return jsonify({'message': 'Workflow successfully launched',
                         'workflow_id': workflow.id_,
                         'workflow_name': _get_workflow_name(workflow),
@@ -1315,11 +1314,10 @@ def run_cwl_workflow_from_spec_endpoint(workflow):  # noqa
             "workflow_json": workflow.get_specification(),
             "parameters": parameters
         }
-        if not os.environ.get("TESTS"):
-            resultobject = run_cwl_workflow.apply_async(
-                kwargs=kwargs,
-                queue=WORKFLOW_QUEUES['cwl']
-            )
+        resultobject = run_cwl_workflow.apply_async(
+            kwargs=kwargs,
+            queue=WORKFLOW_QUEUES['cwl']
+        )
         return jsonify({'message': 'Workflow successfully launched',
                         'workflow_id': str(workflow.id_),
                         'workflow_name': _get_workflow_name(workflow),
@@ -1342,10 +1340,9 @@ def run_serial_workflow_from_spec(workflow, operational_parameters):
             "workflow_parameters": workflow.get_parameters(),
             "operational_parameters": operational_parameters or {},
         }
-        if not os.environ.get("TESTS"):
-            resultobject = run_serial_workflow.apply_async(
-                kwargs=kwargs,
-                queue=WORKFLOW_QUEUES['serial'])
+        resultobject = run_serial_workflow.apply_async(
+            kwargs=kwargs,
+            queue=WORKFLOW_QUEUES['serial'])
         return jsonify({'message': 'Workflow successfully launched',
                         'workflow_id': str(workflow.id_),
                         'workflow_name': _get_workflow_name(workflow),

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ install_requires = [
     'requests==2.11.1',
     'sqlalchemy-utils>=0.31.0',
     'reana-commons>=0.4.0.dev20181016,<0.5.0',
-    'pytest-reana>=0.4.0.dev20181018,<0.5.0',
+    'pytest-reana>=0.4.0.dev201810181,<0.5.0',
     'reana-db>=0.4.0.dev201810181,<0.5.0',
     'uwsgi-tools>=1.1.1',
     'uWSGI>=2.0.17',


### PR DESCRIPTION
* Replaces celery tasks running workflows with Mock objects, and
  asserts that the right arguments are passed.

Depends on https://github.com/reanahub/reana-db/issues/12
Closes https://github.com/reanahub/reana-workflow-controller/issues/132

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>