### PR TITLE
setup: Fix for broken dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
     author_email='info@reana.io',
     url='https://github.com/reanahub/reana-workflow-controller',
     packages=['reana_workflow_controller', ],
+    include_package_data=True,
     zip_safe=False,
     entry_points={
         'flask.commands': [


### PR DESCRIPTION
* Adding include_package_data=True to setup.py, which allows
  to include package subfolders. Closes #160

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>