### PR TITLE
k8s: delete completed pods

### DIFF
--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -73,3 +73,7 @@ SHARED_FS_MAPPING = {
 WORKFLOW_ENGINE_VERSION = parse(__version__).base_version if \
    os.getenv("REANA_DEPLOYMENT_TYPE", 'local') != 'local' else 'latest'
 """CWL workflow engine version."""
+
+TTL_SECONDS_AFTER_FINISHED = 60
+"""Threshold in seconds to clean up terminated (either Complete or Failed)
+jobs."""

--- a/reana_workflow_controller/workflow_run_managers/kubernetes/__init__.py
+++ b/reana_workflow_controller/workflow_run_managers/kubernetes/__init__.py
@@ -11,7 +11,8 @@ from kubernetes import client
 from reana_commons.k8s.api_client import current_k8s_batchv1_api_client
 from reana_workflow_controller.config import (MANILA_CEPHFS_PVC,
                                               SHARED_FS_MAPPING,
-                                              REANA_STORAGE_BACKEND)
+                                              REANA_STORAGE_BACKEND,
+                                              TTL_SECONDS_AFTER_FINISHED)
 from reana_workflow_controller.workflow_run_managers import WorkflowRunManager
 
 
@@ -89,5 +90,6 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         ]
         job.spec = spec
         job.spec.template.spec.restart_policy = 'Never'
+        job.spec.ttl_seconds_after_finished = TTL_SECONDS_AFTER_FINISHED
         job.spec.backoff_limit = 0
         return job


### PR DESCRIPTION
* Setting ttl_seconds_after_finished = 60, to delete completed
  pods. Closes reanahub/reana-workflow-engine-serial/issues/58

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>