### PR TITLE
workflow_run_manager: CVMFS pvc and sc creation

### DIFF
--- a/reana_workflow_controller/rest.py
+++ b/reana_workflow_controller/rest.py
@@ -173,7 +173,8 @@ def get_workflows():  # noqa
                                  'status': workflow.status.name,
                                  'user': user_uuid,
                                  'created': workflow.created.
-                                 strftime(WORKFLOW_TIME_FORMAT)}
+                                 strftime(WORKFLOW_TIME_FORMAT),
+                                 'size': '-'}
             if verbose:
                 reana_fs = fs.open_fs(SHARED_VOLUME_PATH)
                 if reana_fs.exists(workflow.get_workspace()):

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -18,6 +18,8 @@ from kubernetes.client.rest import ApiException
 from reana_commons.k8s.api_client import (current_k8s_batchv1_api_client,
                                           current_k8s_corev1_api_client,
                                           current_k8s_extensions_v1beta1)
+from reana_commons.utils import (create_cvmfs_persistent_volume_claim,
+                                 create_cvmfs_storage_class)
 from reana_workflow_controller.errors import REANAInteractiveSessionError
 from reana_workflow_controller.config import (
     K8S_INTERACTIVE_DEPLOYMENT_TEMPLATE_PATH,
@@ -153,6 +155,9 @@ class WorkflowRunManager():
             cvmfs_env_var = {'name': 'REANA_MOUNT_CVMFS',
                              'value': str(cvmfs_volumes)}
             env_vars.append(cvmfs_env_var)
+            for cvmfs_volume in cvmfs_volumes:
+                create_cvmfs_storage_class(cvmfs_volume)
+                create_cvmfs_persistent_volume_claim(cvmfs_volume)
         return (env_vars)
 
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ install_requires = [
     'kubernetes>=6.0.0',
     'marshmallow>=2.13',
     'packaging>=18.0',
-    'reana-commons>=0.5.0.dev20190215,<0.6.0[kubernetes]',
+    'reana-commons>=0.5.0.dev20190218,<0.6.0[kubernetes]',
     'reana-db>=0.5.0.dev20190213,<0.6.0',
     'requests==2.20.0',
     'sqlalchemy-utils>=0.31.0',

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -62,7 +62,8 @@ def test_get_workflows(app, session, default_user, cwl_workflow_with_name):
                 "name": workflow.name + '.1',  # Add run_number
                 "status": workflow.status.name,
                 "user": str(workflow.owner_id),
-                "created": response_data[0]["created"]
+                "created": response_data[0]["created"],
+                "size": "-"
             }
         ]
 


### PR DESCRIPTION
* Uses utility methods from r-commons to create persistent volume
  claims and storage classes that might not be present in the
  cluster, based on running workflow resource requirements.

Connect https://github.com/reanahub/reana-cluster/issues/154

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>