### PR TITLE
workflow_run_manager: fix mounting unknown volumes

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "description": "Submit and manage workflows",
     "title": "REANA Workflow Controller",
-    "version": "0.5.0.dev20181120"
+    "version": "0.5.0.dev20190220"
   },
   "parameters": {},
   "paths": {

--- a/reana_workflow_controller/version.py
+++ b/reana_workflow_controller/version.py
@@ -14,4 +14,4 @@ This file is imported by ``reana_workflow_controller.__init__`` and parsed by
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.5.0.dev20181120"
+__version__ = "0.5.0.dev20190220"

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -15,6 +15,7 @@ import yaml
 from kubernetes import client
 from kubernetes.client.models.v1_delete_options import V1DeleteOptions
 from kubernetes.client.rest import ApiException
+from reana_commons.config import CVMFS_REPOSITORIES
 from reana_commons.k8s.api_client import (current_k8s_batchv1_api_client,
                                           current_k8s_corev1_api_client,
                                           current_k8s_extensions_v1beta1)
@@ -156,8 +157,10 @@ class WorkflowRunManager():
                              'value': str(cvmfs_volumes)}
             env_vars.append(cvmfs_env_var)
             for cvmfs_volume in cvmfs_volumes:
-                create_cvmfs_storage_class(cvmfs_volume)
-                create_cvmfs_persistent_volume_claim(cvmfs_volume)
+                if cvmfs_volume in CVMFS_REPOSITORIES:
+                    create_cvmfs_storage_class(cvmfs_volume)
+                    create_cvmfs_persistent_volume_claim(cvmfs_volume)
+
         return (env_vars)
 
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ install_requires = [
     'kubernetes>=6.0.0',
     'marshmallow>=2.13',
     'packaging>=18.0',
-    'reana-commons>=0.5.0.dev20190218,<0.6.0[kubernetes]',
+    'reana-commons>=0.5.0.dev20190220,<0.6.0[kubernetes]',
     'reana-db>=0.5.0.dev20190213,<0.6.0',
     'requests==2.20.0',
     'sqlalchemy-utils>=0.31.0',


### PR DESCRIPTION
* Adds check for unknown cvmfs volumes before attempting to create
  them via the k8s api.

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>