### PR TITLE
k8s: dependent interactive objects

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -399,6 +399,72 @@
         "summary": "Get diff between two workflows."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/close": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "This resource is expecting a workflow to close an interactive session within its workspace.",
+        "operationId": "close_interactive_session",
+        "parameters": [
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Workflow UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The interactive session has been closed.",
+            "examples": {
+              "application/json": {
+                "message": "The interactive session has been closed"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed.",
+            "examples": {
+              "application/json": {
+                "message": "Malformed request."
+              }
+            }
+          },
+          "404": {
+            "description": "Request failed. Either User or Workflow does not exist.",
+            "examples": {
+              "application/json": {
+                "message": "Workflow 256b25f4-4cfb-4684-b7a8-73872ef455a1 does not exist"
+              }
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error."
+          }
+        },
+        "summary": "Close an interactive workflow session."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/logs": {
       "get": {
         "description": "This resource is expecting a workflow UUID and a filename to return its outputs.",

--- a/reana_workflow_controller/k8s.py
+++ b/reana_workflow_controller/k8s.py
@@ -163,8 +163,8 @@ build_interactive_k8s_objects = {
 """Build interactive k8s deployment objects."""
 
 
-def instantiate_k8s_objects(kubernetes_objects, namespace):
-    """Instantiate Kubernetes objects.
+def instantiate_chained_k8s_objects(kubernetes_objects, namespace):
+    """Instantiate chained Kubernetes objects.
 
     :param kubernetes_objects: Dictionary composed by the object kind as
         key and the object itself as value.
@@ -199,7 +199,8 @@ def instantiate_k8s_objects(kubernetes_objects, namespace):
         raise Exception("Unsupported Kubernetes object kind {}.".format(kind))
     except ApiException as e:
         raise Exception("Exception when calling ExtensionsV1beta1Api->"
-                        "create_namespaced_deployment_rollback: %s\n" % e)
+                        "create_namespaced_deployment_rollback: {}\n"
+                        .format(e))
 
 
 def delete_k8s_objects_if_exist(kubernetes_objects, namespace):
@@ -232,3 +233,24 @@ def delete_k8s_objects_if_exist(kubernetes_objects, namespace):
                     raise
     except KeyError:
         raise Exception("Unsupported Kubernetes object kind {}.".format(kind))
+
+
+def delete_k8s_ingress_object(ingress_name, namespace):
+    """Delete Kubernetes ingress object.
+
+    :param ingress_name: name of ingress object to delete.
+    :param namespace: k8s namespace of ingress object.
+    """
+    try:
+        current_k8s_extensions_v1beta1.delete_namespaced_ingress(
+            name=ingress_name,
+            namespace=namespace,
+            body=client.V1DeleteOptions()
+        )
+    except ApiException as k8s_api_exception:
+        if k8s_api_exception.reason == "Not Found":
+            raise Exception("K8s object was not found {}."
+                            .format(ingress_name))
+        raise Exception("Exception when calling ExtensionsV1beta1->"
+                        "Api->delete_namespaced_ingress: {}\n"
+                        .format(k8s_api_exception))

--- a/reana_workflow_controller/rest.py
+++ b/reana_workflow_controller/rest.py
@@ -17,6 +17,11 @@ import traceback
 from datetime import datetime
 from uuid import UUID, uuid4
 
+from reana_db.database import Session
+from reana_db.models import Job, User, Workflow, WorkflowStatus
+from reana_db.utils import _get_workflow_with_uuid_or_name
+from werkzeug.exceptions import NotFound
+
 import fs
 from flask import (Blueprint, abort, current_app, jsonify, request,
                    send_from_directory)
@@ -24,20 +29,15 @@ from fs.errors import CreateFailed
 from reana_commons.config import INTERACTIVE_SESSION_TYPES
 from reana_commons.utils import (get_workflow_status_change_verb,
                                  get_workspace_disk_usage)
-from reana_db.database import Session
-from reana_db.models import Job, User, Workflow, WorkflowStatus
-from reana_db.utils import _get_workflow_with_uuid_or_name
-from werkzeug.exceptions import NotFound
-
-from reana_workflow_controller.config import (
-    DEFAULT_NAME_FOR_WORKFLOWS,
-    SHARED_VOLUME_PATH,
-    WORKFLOW_QUEUES,
-    WORKFLOW_TIME_FORMAT)
+from reana_workflow_controller.config import (DEFAULT_NAME_FOR_WORKFLOWS,
+                                              SHARED_VOLUME_PATH,
+                                              WORKFLOW_QUEUES,
+                                              WORKFLOW_TIME_FORMAT)
 from reana_workflow_controller.errors import (REANAUploadPathError,
                                               REANAWorkflowControllerError,
                                               REANAWorkflowDeletionError,
                                               REANAWorkflowNameError)
+from reana_workflow_controller.k8s import delete_k8s_ingress_object
 from reana_workflow_controller.utils import (create_workflow_workspace,
                                              list_directory_files,
                                              remove_files_recursive_wildcard,
@@ -1261,6 +1261,89 @@ def open_interactive_session(workflow_id_or_name, interactive_session_type):  # 
           interactive_session_type,
           image=interactive_session_configuration.get("image", None))
         return jsonify({"path": "{}".format(access_path)}), 200
+
+    except (KeyError, ValueError) as e:
+        status_code = 400 if workflow else 404
+        return jsonify({"message": str(e)}), status_code
+    except Exception as e:
+        return jsonify({"message": str(e)}), 500
+
+
+@restapi_blueprint.route('/workflows/<workflow_id_or_name>/close',
+                         methods=['POST'])
+def close_interactive_session(workflow_id_or_name):  # noqa
+    r"""Close an interactive workflow session.
+
+    ---
+    post:
+      summary: Close an interactive workflow session.
+      description: >-
+        This resource is expecting a workflow to close an interactive session
+        within its workspace.
+      operationId: close_interactive_session
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: user
+          in: query
+          description: Required. UUID of workflow owner.
+          required: true
+          type: string
+        - name: workflow_id_or_name
+          in: path
+          description: Required. Workflow UUID or name.
+          required: true
+          type: string
+      responses:
+        200:
+          description: >-
+            Request succeeded. The interactive session has been closed.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "The interactive session has been closed",
+              }
+        400:
+          description: >-
+            Request failed. The incoming data specification seems malformed.
+          examples:
+            application/json:
+              {
+                "message": "Malformed request."
+              }
+        404:
+          description: >-
+            Request failed. Either User or Workflow does not exist.
+          examples:
+            application/json:
+              {
+                "message": "Workflow 256b25f4-4cfb-4684-b7a8-73872ef455a1
+                            does not exist"
+              }
+        500:
+          description: >-
+            Request failed. Internal controller error.
+    """
+    try:
+        user_uuid = request.args["user"]
+        workflow = None
+        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name,
+                                                   user_uuid)
+        if workflow.interactive_session_name is None:
+            return jsonify(
+                {"message": "Workflow - {} has no open interactive session."
+                            .format(workflow_id_or_name)}), 404
+        kwrm = KubernetesWorkflowRunManager(workflow)
+        kwrm.stop_interactive_session()
+        return jsonify(
+            {"message": "The interactive session has been closed"}), 200
 
     except (KeyError, ValueError) as e:
         status_code = 400 if workflow else 404

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -35,7 +35,8 @@ from reana_workflow_controller.config import (
     WORKFLOW_ENGINE_COMMON_ENV_VARS_DEBUG)
 from reana_workflow_controller.k8s import (build_interactive_k8s_objects,
                                            delete_k8s_objects_if_exist,
-                                           instantiate_k8s_objects)
+                                           instantiate_chained_k8s_objects,
+                                           delete_k8s_ingress_object)
 
 
 class WorkflowRunManager():
@@ -215,17 +216,17 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                         interactive_session_type))
             access_path = self._generate_interactive_workflow_path()
             self.workflow.interactive_session = access_path
-
             workflow_run_name = \
                 self._workflow_run_name_generator(
                     'interactive', type=interactive_session_type)
+            self.workflow.interactive_session_name = workflow_run_name
             kubernetes_objects = \
                 build_interactive_k8s_objects[interactive_session_type](
                     workflow_run_name, access_path,
                     access_token=self.workflow.get_owner_access_token(),
                     **kwargs)
 
-            instantiate_k8s_objects(
+            instantiate_chained_k8s_objects(
                 kubernetes_objects,
                 KubernetesWorkflowRunManager.default_namespace)
             return access_path
@@ -259,6 +260,18 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
             current_db_sessions = Session.object_session(self.workflow)
             current_db_sessions.add(self.workflow)
             current_db_sessions.commit()
+
+    def stop_interactive_session(self):
+        """Stop an interactive workflow run."""
+        delete_k8s_ingress_object(
+            ingress_name=self.workflow.interactive_session_name,
+            namespace=KubernetesWorkflowRunManager.default_namespace
+        )
+        self.workflow.interactive_session_name = None
+        self.workflow.interactive_session = None
+        current_db_sessions = Session.object_session(self.workflow)
+        current_db_sessions.add(self.workflow)
+        current_db_sessions.commit()
 
     def stop_batch_workflow_run(self, workflow_run_jobs=None):
         """Stop a batch workflow run along with all its dependent jobs.

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -759,7 +759,7 @@ def test_start_input_parameters(app, session, default_user,
         # create workflow
         sample_yadage_workflow_in_db.status = WorkflowStatus.created
         workflow_created_uuid = sample_yadage_workflow_in_db.id_
-        session.add(sample_yadage_workflow_in_db)
+        session.add()
         session.commit()
         workflow = Workflow.query.filter(
             Workflow.id_ == workflow_created_uuid).first()
@@ -1091,3 +1091,44 @@ def test_create_interactive_session_custom_image(app, default_user,
                 .create_namespaced_deployment.call_args
             assert fargs[1].spec.template.spec.containers[0].image ==\
                 custom_image
+
+
+def test_close_interactive_session(app, session, default_user,
+                                   sample_serial_workflow_in_db):
+    """Test close an interactive session."""
+    expected_data = {"message": "The interactive session has been closed"}
+    sample_serial_workflow_in_db.interactive_session = \
+        "/5d9b30fd-f225-4615-9107-b1373afec070"
+    sample_serial_workflow_in_db.interactive_session_name = \
+        "interactive-jupyter-5d9b30fd-f225-4615-9107-b1373afec070-5lswkp"
+    session.add(sample_serial_workflow_in_db)
+    session.commit()
+    with app.test_client() as client:
+        with mock.patch(
+                "reana_workflow_controller.k8s.current_k8s_extensions_v1beta1") as mocks:
+            res = client.post(
+                url_for("api.close_interactive_session",
+                        workflow_id_or_name=sample_serial_workflow_in_db.id_),
+                query_string={"user": default_user.id_},
+                content_type='application/json')
+        assert res.json == expected_data
+
+
+def test_close_interactive_session_not_opened(app, session, default_user,
+                                              sample_serial_workflow_in_db):
+    """Test close an interactive session when session is not opened."""
+    expected_data = \
+        {"message": "Workflow - {} has no open interactive session."
+                    .format(sample_serial_workflow_in_db.id_)}
+    with app.test_client() as client:
+        sample_serial_workflow_in_db.interactive_session = None
+        sample_serial_workflow_in_db.interactive_session_name = None
+        session.add(sample_serial_workflow_in_db)
+        session.commit()
+        res = client.post(
+            url_for("api.close_interactive_session",
+                    workflow_id_or_name=sample_serial_workflow_in_db.id_),
+            query_string={"user": default_user.id_},
+            content_type='application/json')
+        assert res.json == expected_data
+        assert res._status_code == 404


### PR DESCRIPTION
* Makes k8s objects created for an interactive session dependent.
  If ingress object gets deleted, service and deployment objects
  are deleted automaticallyi.
  Closes reanahub/reana-client/issues/247

Signed-off-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>