### PR TITLE
cli: fix stop command exception

### DIFF
--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -291,7 +291,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
             current_k8s_batchv1_api_client.delete_namespaced_job(
                 job,
                 KubernetesWorkflowRunManager.default_namespace,
-                V1DeleteOptions(propagation_policy='Background'))
+                body=V1DeleteOptions(propagation_policy='Background'))
 
     def _create_job_spec(self, name, command=None, image=None,
                          env_vars=None):


### PR DESCRIPTION
* fix wrong number of positional arguments exception

* Closes reanahub/reana-client#291

* Same problem as in reanahub/reana-job-controller/pull/128

Signed-off-by: Jan Okraska <jan.okraska@cern.ch>