### PR TITLE
volumes: fix root path

### DIFF
--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -325,14 +325,10 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         owner_id = str(self.workflow.owner_id)
         command = format_cmd(command)
         workspace_mount, _ = get_shared_volume(
-            self.workflow.get_workspace(),
-            KubernetesWorkflowRunManager.k8s_shared_volume
-            [REANA_STORAGE_BACKEND]['hostPath']['path']
+            self.workflow.get_workspace(), SHARED_VOLUME_PATH
         )
         db_mount, _ = get_shared_volume(
-            'db',
-            KubernetesWorkflowRunManager.k8s_shared_volume
-            [REANA_STORAGE_BACKEND]['hostPath']['path']
+            'db', SHARED_VOLUME_PATH
         )
 
         workflow_metadata = client.V1ObjectMeta(name=name)

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -426,7 +426,12 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
             {
                 'name': 'REANA_SQLALCHEMY_DATABASE_URI',
                 'value': SQLALCHEMY_DATABASE_URI
-            }])
+            },
+            {
+                'name': 'REANA_STORAGE_BACKEND',
+                'value': REANA_STORAGE_BACKEND
+            }
+            ])
 
         job_controller_container.volume_mounts = [workspace_mount, db_mount]
         job_controller_container.volume_mounts.append(


### PR DESCRIPTION
* In the case of CEPHFS there is no hostPath available to
  retrieve the root path, leading to a KeyError exception.
  Instead we get the root path from the globally configured
  `SHARED_VOLUME_PATH` variable (configured by REANA-Cluster).