### PR TITLE
api: stream file uploads using request.stream

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1024,7 +1024,7 @@
       },
       "post": {
         "consumes": [
-          "multipart/form-data"
+          "application/octet-stream"
         ],
         "description": "This resource is expecting a workflow UUID and a file to place in the workspace.",
         "operationId": "upload_file",
@@ -1045,10 +1045,12 @@
           },
           {
             "description": "Required. File to add to the workspace.",
-            "in": "formData",
-            "name": "file_content",
+            "in": "body",
+            "name": "file",
             "required": true,
-            "type": "file"
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "description": "Required. File name.",

--- a/reana_workflow_controller/rest.py
+++ b/reana_workflow_controller/rest.py
@@ -453,9 +453,8 @@ def upload_file(workflow_id_or_name):
             if not os.path.exists(absolute_workspace_path):
                 os.makedirs(absolute_workspace_path)
         absolute_file_path = os.path.join(absolute_workspace_path, filename)
-        with open(absolute_file_path, 'wb') as fdest:
-            shutil.copyfileobj(request.stream, fdest)
 
+        FileStorage(request.stream).save(absolute_file_path, buffer_size=32768)
         return jsonify(
           {'message': '{} has been successfully uploaded.'.format(
             full_file_name)}), 200
@@ -466,7 +465,7 @@ def upload_file(workflow_id_or_name):
                                    'Please set your REANA_WORKON environment'
                                    'variable appropriately.'.
                                    format(workflow_id_or_name)}), 404
-    except (KeyError, ) as e:
+    except KeyError as e:
         return jsonify({"message": str(e)}), 400
     except Exception as e:
         return jsonify({"message": str(e)}), 500

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -633,9 +633,8 @@ def test_upload_file(app, session, default_user,
                     workflow_id_or_name=workflow_uuid),
             query_string={"user": default_user.id_,
                           "file_name": file_name},
-            content_type='multipart/form-data',
-            data={'file_content': (io.BytesIO(file_binary_content),
-                                   file_name)})
+            content_type='application/octet-stream',
+            input_stream=io.BytesIO(file_binary_content))
         assert res.status_code == 200
         # remove workspace directory from path
         workflow_workspace = workflow.get_workspace()
@@ -664,9 +663,8 @@ def test_upload_file_unknown_workflow(app, default_user):
                     workflow_id_or_name=random_workflow_uuid),
             query_string={"user": default_user.id_,
                           "file_name": file_name},
-            content_type='multipart/form-data',
-            data={'file_content': (io.BytesIO(file_binary_content),
-                                   file_name)})
+            content_type='application/octet-stream',
+            input_stream=io.BytesIO(file_binary_content))
         assert res.status_code == 404
 
 


### PR DESCRIPTION
* After the findings in
  https://github.com/diegodelemos/client-server-flask-big-file-uploads
  it is clear we have to move from multipart uploads to stream uploads
  using `request.stream` directly (closes reanahub/reana-client#302).