### PR TITLE
workflow_run_manager: tell RJC if EOS is available

### DIFF
--- a/reana_workflow_controller/consumer.py
+++ b/reana_workflow_controller/consumer.py
@@ -34,7 +34,7 @@ class JobStatusConsumer(BaseConsumer):
     """Consumer of jobs-status queue."""
 
     def __init__(self):
-        """Constructor."""
+        """Initialise JobStatusConsumer class."""
         super(JobStatusConsumer, self).__init__(queue='jobs-status')
 
     def get_consumers(self, Consumer, channel):

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -16,6 +16,7 @@ from kubernetes.client.models.v1_delete_options import V1DeleteOptions
 from kubernetes.client.rest import ApiException
 from reana_commons.config import (CVMFS_REPOSITORIES,
                                   INTERACTIVE_SESSION_TYPES,
+                                  K8S_CERN_EOS_AVAILABLE,
                                   REANA_STORAGE_BACKEND, SHARED_VOLUME_PATH,
                                   WORKFLOW_RUNTIME_USER_GID,
                                   WORKFLOW_RUNTIME_USER_NAME,
@@ -384,6 +385,10 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
             }, {
                 'name': 'USER',  # Required by HTCondor
                 'value': user
+            },
+            {
+                'name': 'K8S_CERN_EOS_AVAILABLE',
+                'value': K8S_CERN_EOS_AVAILABLE
             }
         ])
         job_controller_container.env.extend(job_controller_env_vars)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_requires = [
     'jsonpickle>=0.9.6',
     'marshmallow>2.13.0,<=2.20.1',
     'packaging>=18.0',
-    'reana-commons[kubernetes]>=0.6.0.dev20191129,<0.7.0',
+    'reana-commons[kubernetes]>=0.6.0.dev20191210,<0.7.0',
     'reana-db>=0.6.0.dev20190828,<0.7.0',
     'requests==2.20.0',
     'sqlalchemy-utils>=0.31.0',


### PR DESCRIPTION
* From a deployment phase (instantiation of the REANA cluster with
  `reana-cluster init`) the admin tells if EOS is available in the
  underlying Kubernetes cluster. RWC receives this information from
  the environment and passes it over to RJC, which is instantiated
  on demand. It is interesting to have this information here since
  RWC instantiates also interactive sessions which could benefit
  also from mounting EOS (closes reanahub/reana#216).