### PR TITLE
k8s: use apps and networking APIs

### DIFF
--- a/reana_workflow_controller/k8s.py
+++ b/reana_workflow_controller/k8s.py
@@ -13,7 +13,7 @@ from kubernetes.client.rest import ApiException
 from reana_commons.config import REANA_WORKFLOW_UMASK
 from reana_commons.k8s.api_client import (current_k8s_appsv1_api_client,
                                           current_k8s_corev1_api_client,
-                                          current_k8s_extensions_v1beta1)
+                                          current_k8s_networking_v1beta1)
 from reana_commons.k8s.volumes import get_shared_volume
 
 from reana_workflow_controller.config import (  # isort:skip
@@ -64,18 +64,18 @@ class InteractiveDeploymentK8sBuilder(object):
         :param metadata: Common Kubernetes metadata for the interactive
             deployment.
         """
-        ingress_backend = client.ExtensionsV1beta1IngressBackend(
+        ingress_backend = client.NetworkingV1beta1IngressBackend(
             service_name=self.deployment_name,
             service_port=InteractiveDeploymentK8sBuilder.internal_service_port
         )
-        ingress_rule_value = client.ExtensionsV1beta1HTTPIngressRuleValue([
-            client.ExtensionsV1beta1HTTPIngressPath(
+        ingress_rule_value = client.NetworkingV1beta1HTTPIngressRuleValue([
+            client.NetworkingV1beta1HTTPIngressPath(
                 path=self.path, backend=ingress_backend)])
-        spec = client.ExtensionsV1beta1IngressSpec(
-            rules=[client.ExtensionsV1beta1IngressRule(
+        spec = client.NetworkingV1beta1IngressSpec(
+            rules=[client.NetworkingV1beta1IngressRule(
                 http=ingress_rule_value)])
-        ingress = client.ExtensionsV1beta1Ingress(
-            api_version="extensions/v1beta1",
+        ingress = client.NetworkingV1beta1Ingress(
+            api_version="networking.k8s.io/v1beta1",
             kind="Ingress",
             spec=spec,
             metadata=metadata,
@@ -237,7 +237,7 @@ def instantiate_chained_k8s_objects(kubernetes_objects, namespace):
         "service":
         current_k8s_corev1_api_client.create_namespaced_service,
         "ingress":
-        current_k8s_extensions_v1beta1.create_namespaced_ingress
+        current_k8s_networking_v1beta1.create_namespaced_ingress
     }
     try:
         parent_k8s_object_references = None
@@ -274,19 +274,18 @@ def delete_k8s_objects_if_exist(kubernetes_objects, namespace):
     """
     delete_k8s_object = {
         "deployment":
-        current_k8s_extensions_v1beta1.delete_namespaced_deployment,
+        current_k8s_appsv1_api_client.delete_namespaced_deployment,
         "service":
         current_k8s_corev1_api_client.delete_namespaced_service,
         "ingress":
-        current_k8s_extensions_v1beta1.delete_namespaced_ingress
+        current_k8s_networking_v1beta1.delete_namespaced_ingress
     }
     try:
         for obj in kubernetes_objects.items():
             try:
                 kind = obj[0]
                 k8s_object = obj[1]
-                delete_k8s_object[kind](k8s_object.metadata.name, namespace,
-                                        body=k8s_object)
+                delete_k8s_object[kind](k8s_object.metadata.name, namespace)
             except ApiException as k8s_api_exception:
                 if k8s_api_exception.reason == "Not Found":
                     continue
@@ -303,7 +302,7 @@ def delete_k8s_ingress_object(ingress_name, namespace):
     :param namespace: k8s namespace of ingress object.
     """
     try:
-        current_k8s_extensions_v1beta1.delete_namespaced_ingress(
+        current_k8s_networking_v1beta1.delete_namespaced_ingress(
             name=ingress_name,
             namespace=namespace,
             body=client.V1DeleteOptions()

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -17,6 +17,7 @@ from kubernetes.client.rest import ApiException
 from reana_commons.config import (CVMFS_REPOSITORIES,
                                   INTERACTIVE_SESSION_TYPES,
                                   K8S_CERN_EOS_AVAILABLE,
+                                  K8S_REANA_SERVICE_ACCOUNT_NAME,
                                   REANA_STORAGE_BACKEND, SHARED_VOLUME_PATH,
                                   WORKFLOW_RUNTIME_USER_GID,
                                   WORKFLOW_RUNTIME_USER_NAME,
@@ -416,6 +417,8 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         containers = [workflow_enginge_container, job_controller_container]
         spec.template.spec = client.V1PodSpec(
             containers=containers)
+        spec.template.spec.service_account_name = \
+            K8S_REANA_SERVICE_ACCOUNT_NAME
         spec.template.spec.volumes = [
             workspace_volume,
             secrets_store.get_file_secrets_volume_as_k8s_specs(),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1056,7 +1056,7 @@ def test_create_interactive_session(app, default_user,
         with mock.patch.multiple(
                 'reana_workflow_controller.k8s',
                 current_k8s_corev1_api_client=mock.DEFAULT,
-                current_k8s_extensions_v1beta1=mock.DEFAULT,
+                current_k8s_networking_v1beta1=mock.DEFAULT,
                 current_k8s_appsv1_api_client=mock.DEFAULT) as mocks:
             res = client.post(
                 url_for("api.open_interactive_session",
@@ -1089,7 +1089,7 @@ def test_create_interactive_session_custom_image(app, default_user,
         with mock.patch.multiple(
                 "reana_workflow_controller.k8s",
                 current_k8s_corev1_api_client=mock.DEFAULT,
-                current_k8s_extensions_v1beta1=mock.DEFAULT,
+                current_k8s_networking_v1beta1=mock.DEFAULT,
                 current_k8s_appsv1_api_client=mock.DEFAULT) as mocks:
             res = client.post(
                 url_for("api.open_interactive_session",
@@ -1117,7 +1117,7 @@ def test_close_interactive_session(app, session, default_user,
     with app.test_client() as client:
         with mock.patch(
                 "reana_workflow_controller.k8s"
-                ".current_k8s_extensions_v1beta1") as mocks:
+                ".current_k8s_networking_v1beta1") as mocks:
             res = client.post(
                 url_for("api.close_interactive_session",
                         workflow_id_or_name=sample_serial_workflow_in_db.id_),

--- a/tests/test_workflow_run_manager.py
+++ b/tests/test_workflow_run_manager.py
@@ -28,7 +28,7 @@ def test_start_interactive_session(sample_serial_workflow_in_db):
     """Test interactive workflow run deployment."""
     with patch.multiple("reana_workflow_controller.k8s",
                         current_k8s_corev1_api_client=DEFAULT,
-                        current_k8s_extensions_v1beta1=DEFAULT,
+                        current_k8s_networking_v1beta1=DEFAULT,
                         current_k8s_appsv1_api_client=DEFAULT) as mocks:
         kwrm = KubernetesWorkflowRunManager(sample_serial_workflow_in_db)
         if len(INTERACTIVE_SESSION_TYPES):
@@ -37,7 +37,7 @@ def test_start_interactive_session(sample_serial_workflow_in_db):
             create_namespaced_deployment.assert_called_once()
         mocks['current_k8s_corev1_api_client'].\
             create_namespaced_service.assert_called_once()
-        mocks['current_k8s_extensions_v1beta1'].\
+        mocks['current_k8s_networking_v1beta1'].\
             create_namespaced_ingress.assert_called_once()
 
 
@@ -49,7 +49,7 @@ def test_start_interactive_workflow_k8s_failure(sample_serial_workflow_in_db):
     with patch.multiple('reana_workflow_controller.k8s',
                         current_k8s_appsv1_api_client=mocked_k8s_client,
                         current_k8s_corev1_api_client=DEFAULT,
-                        current_k8s_extensions_v1beta1=DEFAULT):
+                        current_k8s_networking_v1beta1=DEFAULT):
         with pytest.raises(REANAInteractiveSessionError,
                            match=r'.*Kubernetes has failed.*'):
             kwrm = KubernetesWorkflowRunManager(sample_serial_workflow_in_db)
@@ -72,7 +72,8 @@ def test_atomic_creation_of_interactive_session(sample_serial_workflow_in_db):
         Mock(side_effect=ApiException(
              reason='Not Found'))
     with patch.multiple('reana_workflow_controller.k8s',
-                        current_k8s_extensions_v1beta1=mocked_k8s_client,
+                        current_k8s_appsv1_api_client=mocked_k8s_client,
+                        current_k8s_networking_v1beta1=DEFAULT,
                         current_k8s_corev1_api_client=DEFAULT) as mocks:
         try:
             kwrm = KubernetesWorkflowRunManager(sample_serial_workflow_in_db)
@@ -81,7 +82,8 @@ def test_atomic_creation_of_interactive_session(sample_serial_workflow_in_db):
         except REANAInteractiveSessionError:
             mocks['current_k8s_corev1_api_client']\
                 .delete_namespaced_service.assert_called_once()
-            mocked_k8s_client.delete_namespaced_ingress.assert_called_once()
+            mocks['current_k8s_networking_v1beta1']\
+                .delete_namespaced_ingress.assert_called_once()
             mocked_k8s_client.delete_namespaced_deployment.assert_called_once()
             assert sample_serial_workflow_in_db.interactive_session is None
 


### PR DESCRIPTION
* Extensions API gets will get deprecated Ingressses this commit
  switches to the new Networking API.

* Change deletion of Deployments to use `apps` API which was missing
  in the Kubernetes 1.16 upgrade (closes #267).