### PR TITLE
workflow_run_manager: add code mount in dev mode

### DIFF
--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -85,9 +85,11 @@ WORKFLOW_ENGINE_COMMON_ENV_VARS = [
 """Common to all workflow engines environment variables."""
 
 DEBUG_ENV_VARS = ({'name': 'WDB_SOCKET_SERVER',
-                   'value': 'wdb'},
+                   'value': 'reana-wdb'},
                   {'name': 'WDB_NO_BROWSER_AUTO_OPEN',
-                   'value': 'True'})
+                   'value': 'True'},
+                  {'name': 'FLASK_ENV',
+                   'value': 'development'})
 """Common to all workflow engines environment variables for debug mode."""
 
 TTL_SECONDS_AFTER_FINISHED = 60

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -329,7 +329,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
             template=client.V1PodTemplateSpec())
         spec.template.metadata = workflow_metadata
 
-        workflow_enginge_container = client.V1Container(
+        workflow_engine_container = client.V1Container(
             name=current_app.config['WORKFLOW_ENGINE_NAME'],
             image=image,
             image_pull_policy='IfNotPresent',
@@ -348,13 +348,13 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                 'value': 'localhost'}
         ]
         workflow_engine_env_vars.extend(job_controller_address)
-        workflow_enginge_container.env.extend(workflow_engine_env_vars)
-        workflow_enginge_container.security_context = \
+        workflow_engine_container.env.extend(workflow_engine_env_vars)
+        workflow_engine_container.security_context = \
             client.V1SecurityContext(
                 run_as_group=WORKFLOW_RUNTIME_USER_GID,
                 run_as_user=WORKFLOW_RUNTIME_USER_UID
             )
-        workflow_enginge_container.volume_mounts = [workspace_mount]
+        workflow_engine_container.volume_mounts = [workspace_mount]
         secrets_store = REANAUserSecretsStore(owner_id)
         job_controller_env_secrets = secrets_store.\
             get_env_secrets_as_k8s_spec()
@@ -415,7 +415,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
             "containerPort":
                 current_app.config['JOB_CONTROLLER_CONTAINER_PORT']
         }]
-        containers = [workflow_enginge_container, job_controller_container]
+        containers = [workflow_engine_container, job_controller_container]
         spec.template.spec = client.V1PodSpec(
             containers=containers)
         spec.template.spec.service_account_name = \


### PR DESCRIPTION
* Adds REANA code mounted to runtime pods (RWE_ and RJC) when
  FLASK_ENV is `development`. We assume that when REANA is installed
  in dev mode, minikube will have all REANA source code under `/code`
  this safe to assume since it is part of our Makefile procedures
  (we do not allow to run REANA in dev mode without the mount active).