### PR TITLE
workflow_run_manager: pass workflow file if exists

### DIFF
--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -63,6 +63,7 @@ class WorkflowRunManager():
                             "--workflow-uuid {id} "
                             "--workflow-workspace {workspace} "
                             "--workflow-json '{workflow_json}' "
+                            "--workflow-file '{workflow_file}' "
                             "--workflow-parameters '{parameters}' "
                             "--operational-options '{options}' "),
                 'environment_variables': WORKFLOW_ENGINE_COMMON_ENV_VARS},
@@ -72,6 +73,7 @@ class WorkflowRunManager():
                                "--workflow-uuid {id} "
                                "--workflow-workspace {workspace} "
                                "--workflow-json '{workflow_json}' "
+                               "--workflow-file '{workflow_file}' "
                                "--workflow-parameters '{parameters}' "),
                    'environment_variables': WORKFLOW_ENGINE_COMMON_ENV_VARS},
         'serial': {'image': '{}'.
@@ -181,6 +183,8 @@ class WorkflowRunManager():
                     workspace=self.workflow.get_workspace(),
                     workflow_json=base64.standard_b64encode(json.dumps(
                         self.workflow.get_specification()).encode()),
+                    workflow_file=self.workflow.reana_specification.get(
+                        'workflow').get('file'),
                     parameters=base64.standard_b64encode(json.dumps(
                         self._get_merged_workflow_input_parameters(
                             overwrite=overwrite_input_parameters


### PR DESCRIPTION
* There will be cases (i.e. integration with Git providers) in
  which there won't be a workflow specification stored in the
  database. This only happens when a submission doesn't come from a REANA
  client. So in these cases, by knowing the path of the workflow
  file, the workflow engines can load with their specific libraries
  the workflow files (which we will optimistically assume are there
  if not, workflow engine should fail saying there is no workflow
  to be processed) (closes reanahub/reana#235).