### PR TITLE
workflow_run_manager: workflow stop race condition

### DIFF
--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -11,7 +11,7 @@
 import os
 
 from packaging.version import parse
-from reana_commons.config import SHARED_VOLUME_PATH
+from reana_commons.config import REANA_COMPONENT_PREFIX, SHARED_VOLUME_PATH
 
 from reana_workflow_controller.version import __version__
 
@@ -67,7 +67,8 @@ WORKFLOW_ENGINE_COMMON_ENV_VARS = [
 """Common to all workflow engines environment variables."""
 
 DEBUG_ENV_VARS = ({'name': 'WDB_SOCKET_SERVER',
-                   'value': 'reana-wdb'},
+                   'value': os.getenv('WDB_SOCKET_SERVER',
+                                      f'{REANA_COMPONENT_PREFIX}-wdb')},
                   {'name': 'WDB_NO_BROWSER_AUTO_OPEN',
                    'value': 'True'},
                   {'name': 'FLASK_ENV',

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -318,7 +318,9 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                 current_k8s_batchv1_api_client.delete_namespaced_job(
                     job,
                     KubernetesWorkflowRunManager.default_namespace,
-                    body=V1DeleteOptions(propagation_policy='Background'))
+                    body=V1DeleteOptions(
+                        grace_period_seconds=0,
+                        propagation_policy='Background'))
             except ApiException:
                 logging.error(f'Error while trying to stop {self.workflow.id_}'
                               f': Kubernetes job {job} could not be deleted.',


### PR DESCRIPTION
* Happening when user stops a workflow before its first job is created.
  RWC stops only the existing jobs. However, because there is a grace
  period for stopping pods, RJC sidecar still runs, submitting a new
  job, and reporting its status, causing the workflow to “revive”
  (closes reanahub/reana-client#395).