### PR TITLE
config: use centrally configured k8s namespace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Version master (UNRELEASED)
 - Adds progress report on workflow list response.
 - Makes CVMFS available in interactive sessions.
 - Adds preview flag to file download endpoint.
+- Creates REANA runtime components in the centrally configured (REANA-Commons) runtime namespace.
 - Fixes jobs status update.
 - Labels workflow engine pods for better traceability.
 - Enriches logs enpoint information.


### PR DESCRIPTION
* In order to be able to deploy REANA in different Kubernetes
  namespaces we use the centrally configured variable from
  REANA-Commons which represents it. This configuration happens
  at deployment time (closes reanahub/reana#274).
* Creates REANA runtime objects in the configured runtime namespace.
  Note that if no runtime namespace is configured by default it will
  be the same as the infrastructure pods namespace
  (closes reanahub/reana#268).