### PR TITLE
models: REANA-DB to manage workflow status change

### DIFF
--- a/reana_workflow_controller/consumer.py
+++ b/reana_workflow_controller/consumer.py
@@ -112,7 +112,6 @@ def _update_workflow_status(workflow, status, logs):
             WorkflowStatus.queued,
         ]
         if status not in alive_statuses:
-            workflow.run_finished_at = datetime.now()
             _delete_workflow_engine_pod(workflow)
 
 

--- a/reana_workflow_controller/rest/utils.py
+++ b/reana_workflow_controller/rest/utils.py
@@ -47,7 +47,6 @@ def start_workflow(workflow, parameters):
     """Start a workflow."""
 
     def _start_workflow_db(workflow, parameters):
-        workflow.run_started_at = datetime.now()
         workflow.status = WorkflowStatus.running
         if parameters:
             workflow.input_parameters = parameters.get("input_parameters")
@@ -107,12 +106,10 @@ def stop_workflow(workflow):
     """Stop a given workflow."""
     if workflow.status == WorkflowStatus.running:
         kwrm = KubernetesWorkflowRunManager(workflow)
-        workflow.run_stopped_at = datetime.now()
         kwrm.stop_batch_workflow_run()
         workflow.status = WorkflowStatus.stopped
-        current_db_sessions = Session.object_session(workflow)
-        current_db_sessions.add(workflow)
-        current_db_sessions.commit()
+        Session.add(workflow)
+        Session.commit()
     else:
         message = ("Workflow {id_} is not running.").format(id_=workflow.id_)
         raise REANAWorkflowControllerError(message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ python-editor==1.0.4      # via alembic
 pytz==2020.1              # via bravado-core, fs
 pyyaml==5.3.1             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
 reana-commons[kubernetes]==0.8.0a2	# via reana-db, reana-workflow-controller (setup.py)
-reana-db==0.8.0a2	# via reana-workflow-controller (setup.py)
+reana-db==0.8.0a3	# via reana-workflow-controller (setup.py)
 requests-oauthlib==1.3.0  # via kubernetes
 requests==2.20.0          # via bravado, kubernetes, reana-workflow-controller (setup.py), requests-oauthlib
 rfc3987==1.3.8            # via jsonschema

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ install_requires = [
     "marshmallow>2.13.0,<=2.20.1",
     "packaging>=18.0",
     "reana-commons[kubernetes]>=0.8.0a2,<0.9.0",
-    "reana-db>=0.8.0a2,<0.9.0",
+    "reana-db>=0.8.0a3,<0.9.0",
     "requests==2.20.0",
     "sqlalchemy-utils>=0.31.0",
     "uwsgi-tools>=1.1.1",


### PR DESCRIPTION
* Let REANA-DB atomically manage status change related operations.
  For example, setting the finished/stopped/failed time (removed
  from RWC in this PR), updating quota usage etc...

Closes reanahub/reana-workflow-controller#332.