### PR TITLE
global: configurable job cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 0.7.2 (UNRELEASED)
+--------------------------
+
+- Adds new configuration to toggle Kubernetes user jobs clean up.
+- Fixes ``job-status-consumer`` exception detection for better resilience.
+
 Version 0.7.1 (2021-02-03)
 --------------------------
 

--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -74,10 +74,6 @@ DEBUG_ENV_VARS = (
 )
 """Common to all workflow engines environment variables for debug mode."""
 
-TTL_SECONDS_AFTER_FINISHED = 60
-"""Threshold in seconds to clean up terminated (either Complete or Failed)
-jobs."""
-
 JUPYTER_INTERACTIVE_SESSION_DEFAULT_IMAGE = "jupyter/scipy-notebook"
 """Default image for Jupyter based interactive session deployments."""
 

--- a/reana_workflow_controller/consumer.py
+++ b/reana_workflow_controller/consumer.py
@@ -142,7 +142,8 @@ def _update_workflow_status(workflow, status, logs):
         if status not in ALIVE_STATUSES:
             try:
                 workflow.run_finished_at = datetime.now()
-                _delete_workflow_engine_pod(workflow)
+                if WorkflowStatus.should_cleanup_job(status):
+                    _delete_workflow_engine_pod(workflow)
             except REANAWorkflowControllerError:
                 logging.error(
                     f"Could not clean up workflow engine for workflow {workflow.id_}"

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -22,6 +22,7 @@ from reana_commons.config import (
     REANA_COMPONENT_PREFIX,
     REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE,
     REANA_JOB_HOSTPATH_MOUNTS,
+    REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES,
     REANA_RUNTIME_KUBERNETES_NAMESPACE,
     REANA_RUNTIME_KUBERNETES_NODE_LABEL,
     REANA_RUNTIME_KUBERNETES_SERVICEACCOUNT_NAME,
@@ -62,7 +63,6 @@ from reana_workflow_controller.config import (  # isort:skip
     REANA_WORKFLOW_ENGINE_IMAGE_SERIAL,
     REANA_WORKFLOW_ENGINE_IMAGE_YADAGE,
     SHARED_FS_MAPPING,
-    TTL_SECONDS_AFTER_FINISHED,
     WORKFLOW_ENGINE_COMMON_ENV_VARS,
     DEBUG_ENV_VARS,
 )
@@ -500,6 +500,12 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                     "name": "REANA_JOB_HOSTPATH_MOUNTS",
                     "value": json.dumps(REANA_JOB_HOSTPATH_MOUNTS),
                 },
+                {
+                    "name": "REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES",
+                    "value": ",".join(
+                        REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES
+                    ),
+                },
             ]
         )
         job_controller_container.env.extend(job_controller_env_vars)
@@ -553,7 +559,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
 
         job.spec = spec
         job.spec.template.spec.restart_policy = "Never"
-        job.spec.ttl_seconds_after_finished = TTL_SECONDS_AFTER_FINISHED
+
         job.spec.backoff_limit = 0
         return job
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ python-editor==1.0.4      # via alembic
 pytz==2020.1              # via bravado-core, fs
 pyyaml==5.3.1             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
 reana-commons[kubernetes]==0.7.3  # via reana-db, reana-workflow-controller (setup.py)
-reana-db==0.7.1           # via reana-workflow-controller (setup.py)
+reana-db==0.7.2           # via reana-workflow-controller (setup.py)
 requests-oauthlib==1.3.0  # via kubernetes
 requests==2.20.0          # via bravado, kubernetes, reana-workflow-controller (setup.py), requests-oauthlib
 rfc3987==1.3.8            # via jsonschema

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_requires = [
     "marshmallow>2.13.0,<=2.20.1",
     "packaging>=18.0",
     "reana-commons[kubernetes]>=0.7.3,<0.8.0",
-    "reana-db>=0.7.1,<0.8.0",
+    "reana-db>=0.7.2,<0.8.0",
     "requests==2.20.0",
     "sqlalchemy-utils>=0.31.0",
     "uwsgi-tools>=1.1.1",


### PR DESCRIPTION
* Addresses reanahub/reana#461.

* Removes TTLAfterFinished config since this doesn't work with workflow
  engines because there is RJC as sidecar, and it never completes its execution
  (Flask application). Two solutions were quickly evaluated which either aren't
  too robust or they don't fit into current planning:
  - New endpoint `/shutdown` in RJC, called by RWE when workflow ends
    - The only way found to implement is to explicitly through `RuntimeError`
      inside `/shutdown`, which would make the workflow pod fail.
  - Share folder between containers, write flag to file when workflow finishes.
    - Too convoluted and no time to test thoroughly since we have a workshop
      next week.