### PR TITLE
utils: fix stop workflow

### DIFF
--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -345,7 +345,6 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         to_delete = self.get_workflow_running_jobs_as_backend_ids() + [
             workflow_run_name
         ]
-        error = False
         for job in to_delete:
             try:
                 current_k8s_batchv1_api_client.delete_namespaced_job(
@@ -361,12 +360,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                     f": Kubernetes job {job} could not be deleted.",
                     exc_info=True,
                 )
-                error = True
                 continue
-        if error:
-            raise REANAWorkflowStopError(
-                f"Workflow {self.workflow.id_} could not be stopped."
-            )
 
     def _create_job_spec(
         self,


### PR DESCRIPTION
* Allows workflow stop operation to finalise even if Kubernetes
  call to stop the workflow jobs and its jobs fails. An error is
  logged so administrators can see it and clean up the cluster
  accordingly (closes reanahub/reana-client#360).

To test:
1. Comment the following code in REANA-Commons:
```diff
diff --git a/reana_commons/workflow_engine.py b/reana_commons/workflow_engine.py
index 51bceb2..692fcad 100644
--- a/reana_commons/workflow_engine.py
+++ b/reana_commons/workflow_engine.py
@@ -170,7 +170,7 @@ def create_workflow_engine_command(
                 )
 
         try:
-            signal.signal(signal.SIGTERM, exit_handler or _default_exit_handler)
+            # signal.signal(signal.SIGTERM, exit_handler or _default_exit_handler)
            publisher = WorkflowStatusPublisher()
             rjc_api_client = JobControllerAPIClient("reana-job-controller")
             check_connection_to_job_controller()
@@ -181,18 +181,18 @@ def create_workflow_engine_command(
             publisher.close()
         except Exception as e:
             logging.debug(str(e))
-            if publisher:
-                publisher.publish_workflow_status(
-                    workflow_uuid,
-                    3,
-                    logs="Workflow exited unexpectedly.\n{e}".format(e=e),
-                )
-            else:
-                logging.error(
-                    f"Workflow {workflow_uuid} failed but status "
-                    "could not be published causing the workflow to be "
-                    "stuck in running status.",
-                )
+            # if publisher:
+            #     publisher.publish_workflow_status(
+            #         workflow_uuid,
+            #         3,
+            #         logs="Workflow exited unexpectedly.\n{e}".format(e=e),
+            #     )
+            # else:
+            #     logging.error(
+            #         f"Workflow {workflow_uuid} failed but status "
+            #         "could not be published causing the workflow to be "
+            #         "stuck in running status.",
+            #     )
 
         finally:
```
2. Submit a workflow: `reana-client run`
3. Kill the workflow's `run-batch-xxxx-yyy`
4. `reana-client list` should show the workflow as still running, even if there is no pod running it
5. Run `reana-client stop --force -w workflow`