### PR TITLE
rest: set workflow status to pending after starting the workflow

### DIFF
--- a/reana_workflow_controller/consumer.py
+++ b/reana_workflow_controller/consumer.py
@@ -111,6 +111,7 @@ def _update_workflow_status(workflow, status, logs):
             RunStatus.created,
             RunStatus.running,
             RunStatus.queued,
+            RunStatus.pending,
         ]
         if status not in alive_statuses:
             _delete_workflow_engine_pod(workflow)

--- a/reana_workflow_controller/rest/utils.py
+++ b/reana_workflow_controller/rest/utils.py
@@ -48,7 +48,7 @@ def start_workflow(workflow, parameters):
     """Start a workflow."""
 
     def _start_workflow_db(workflow, parameters):
-        workflow.status = RunStatus.running
+        workflow.status = RunStatus.pending
         if parameters:
             workflow.input_parameters = parameters.get("input_parameters")
             workflow.operational_options = parameters.get("operational_options")
@@ -71,6 +71,7 @@ def start_workflow(workflow, parameters):
                 RunStatus.failed,
                 RunStatus.finished,
                 RunStatus.queued,
+                RunStatus.pending,
             ]:
                 raise REANAWorkflowControllerError(failure_message)
     elif workflow.status not in [RunStatus.created, RunStatus.queued]:
@@ -193,6 +194,7 @@ def delete_workflow(workflow, all_runs=False, workspace=False):
         RunStatus.deleted,
         RunStatus.failed,
         RunStatus.queued,
+        RunStatus.pending,
     ]:
         try:
             to_be_deleted = [workflow]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,7 @@ from reana_workflow_controller.rest.utils import (
         RunStatus.created,
         RunStatus.failed,
         RunStatus.finished,
+        RunStatus.pending,
         RunStatus.stopped,
         pytest.param(RunStatus.deleted, marks=pytest.mark.xfail),
         pytest.param(RunStatus.running, marks=pytest.mark.xfail),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -33,7 +33,7 @@ from reana_workflow_controller.rest.workflows_status import START, STOP
 from reana_workflow_controller.workflow_run_manager import WorkflowRunManager
 
 status_dict = {
-    START: RunStatus.running,
+    START: RunStatus.pending,
     STOP: RunStatus.finished,
 }
 
@@ -608,7 +608,7 @@ def test_start_already_started_workflow(
                 assert res.status_code == 409
                 expected_message = (
                     "Workflow {0} could not be started because"
-                    " it is already running."
+                    " it is already pending."
                 ).format(workflow_created_uuid)
                 assert json_response.get("message") == expected_message
 


### PR DESCRIPTION
closes https://github.com/reanahub/reana-workflow-controller/issues/363

Depends on https://github.com/reanahub/reana-db/pull/123 (tests fail because `pending` status is not present yet)

#### Changes

* Sets workflow status to `pending` right after the workflow has been started
* ~~Adds `get_workflow_status_name()` function to return back the workflow status~~
  - ~~`pending` status should be transparent to the user, therefore in that case the `queued` status is returned~~

* ~~Modifies `get_workflows()` endpoint to include `pending` workflows if filtered by `queued` status~~

#### How to test

I've tested it by running simple `helloworld` demo and modifying [reana_workflow_engine_serial](https://github.com/reanahub/reana-workflow-engine-serial/blob/b9219f631f327b6e1f45e66dbc1f6c364ce0e973/reana_workflow_engine_serial/tasks.py#L152) by adding 
```
import time
time.sleep(20)
```
just before ` publish_workflow_start()`. In this case we can simulate that workflow is stuck a bit in `pending` state.

~~In addition [these lines](https://github.com/reanahub/reana-workflow-controller/blob/0f248dc57812f88e76a56e24cc782dd460545cb0/reana_workflow_controller/rest/utils.py#L137-L138) could be commented to inspect the `pending` status using cli (note that UI will break, since the new state is not supported there)~~