### PR TITLE
workflow_run_manager: fix workspace group problem

### DIFF
--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -633,10 +633,8 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
             add_user_cmd = "useradd -u {} -g {} -M {};".format(
                 WORKFLOW_RUNTIME_USER_UID, WORKFLOW_RUNTIME_USER_GID, user
             )
-            chown_workspace_cmd = "chown -R {}:{} {};".format(
-                WORKFLOW_RUNTIME_USER_UID,
-                WORKFLOW_RUNTIME_USER_GID,
-                self.workflow.workspace_path,
+            chown_workspace_cmd = "chown -R {} {};".format(
+                WORKFLOW_RUNTIME_USER_UID, self.workflow.workspace_path,
             )
             run_app_cmd = 'su {} /bin/bash -c "{}"'.format(user, base_cmd)
             full_cmd = add_group_cmd + add_user_cmd + chown_workspace_cmd + run_app_cmd


### PR DESCRIPTION
closes https://github.com/reanahub/reana-workflow-engine-yadage/issues/210
closes https://github.com/reanahub/reana-server/issues/456

Group id for workspace files was set incorrectly, leading to some problems in `recast` demo when `kubernetes_uid` is set to `500` and using `gid` for writing permissions. 

To test add some sleep time [here in recast demo](https://github.com/reanahub/reana-demo-atlas-recast/blob/master/workflow/steps.yml#L13).
Inspect workflow directory:
```
reana ❯ kubectl exec -it reana-run-batch-de475399-ec1f-4dd0-84c4-8680705dfc59-nq59w  -- bash
Defaulted container "workflow-engine" out of: workflow-engine, job-controller
I have no name!@reana-run-batch-de475399-ec1f-4dd0-84c4-8680705dfc59-nq59w:/code$ cd /var/reana/users/00000000-0000-0000-0000-000000000000/workflows/de475399-ec1f-4dd0-84c4-8680705dfc59/
I have no name!@reana-run-batch-de475399-ec1f-4dd0-84c4-8680705dfc59-nq59w:/var/reana/users/00000000-0000-0000-0000-000000000000/workflows/de475399-ec1f-4dd0-84c4-8680705dfc59$ ls -al
total 24
drwxrwsr-x 6 1000 root 4096 Oct 20 14:30 .
drwxr-xr-x 3 root root 4096 Oct 20 14:30 ..
drwxrwsr-x 3 1000 root 4096 Oct 20 14:30 _yadage
drwxrwsr-x 3 1000 root 4096 Oct 20 14:30 eventselection
drwxrwsr-x 3 1000 root 4096 Oct 20 14:30 statanalysis
drwxrwsr-x 3 1000 root 4096 Oct 20 14:30 workflow
```

Gid for workflow files should be root, instead of 1000 (like it was without this fix)