### PR TITLE
Upgrade interactive sessions to support networking.k8s.io/v1 API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.9.0 (UNRELEASED)
+---------------------------
+
+- Adds support for Kubernetes networking/v1 API to interactive sessions.
+
 Version 0.8.1 (2022-02-07)
 ---------------------------
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2017, 2018, 2019, 2020, 2021 CERN.
+Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "description": "Submit and manage workflows",
     "title": "REANA Workflow Controller",
-    "version": "0.8.1"
+    "version": "0.9.0a1"
   },
   "parameters": {},
   "paths": {

--- a/reana_workflow_controller/k8s.py
+++ b/reana_workflow_controller/k8s.py
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -113,7 +113,7 @@ class InteractiveDeploymentK8sBuilder(object):
             ],
             selector={"app": self.deployment_name},
         )
-        service = client.V1beta1APIService(
+        service = client.V1APIService(
             api_version="v1", kind="Service", spec=spec, metadata=metadata,
         )
         return service

--- a/reana_workflow_controller/k8s.py
+++ b/reana_workflow_controller/k8s.py
@@ -6,8 +6,6 @@
 
 """REANA Workflow Controller Kubernetes utils."""
 
-import os
-
 from kubernetes import client
 from kubernetes.client.rest import ApiException
 from reana_commons.config import (
@@ -18,18 +16,16 @@ from reana_commons.config import (
 from reana_commons.k8s.api_client import (
     current_k8s_appsv1_api_client,
     current_k8s_corev1_api_client,
-    current_k8s_networking_v1beta1,
+    current_k8s_networking_api_client,
 )
 from reana_commons.k8s.volumes import (
     get_k8s_cvmfs_volume,
-    get_shared_volume,
     get_workspace_volume,
 )
 
 from reana_workflow_controller.config import (  # isort:skip
     JUPYTER_INTERACTIVE_SESSION_DEFAULT_IMAGE,
     JUPYTER_INTERACTIVE_SESSION_DEFAULT_PORT,
-    SHARED_VOLUME_PATH,
 )
 
 
@@ -76,22 +72,25 @@ class InteractiveDeploymentK8sBuilder(object):
         :param metadata: Common Kubernetes metadata for the interactive
             deployment.
         """
-        ingress_backend = client.NetworkingV1beta1IngressBackend(
-            service_name=self.deployment_name,
-            service_port=InteractiveDeploymentK8sBuilder.internal_service_port,
+        ingress_service_backend = client.V1IngressServiceBackend(
+            name=self.deployment_name,
+            port=client.V1ServiceBackendPort(
+                number=InteractiveDeploymentK8sBuilder.internal_service_port
+            ),
         )
-        ingress_rule_value = client.NetworkingV1beta1HTTPIngressRuleValue(
+        ingress_backend = client.V1IngressBackend(service=ingress_service_backend)
+        ingress_rule_value = client.V1HTTPIngressRuleValue(
             [
-                client.NetworkingV1beta1HTTPIngressPath(
-                    path=self.path, backend=ingress_backend
+                client.V1HTTPIngressPath(
+                    path=self.path, backend=ingress_backend, path_type="Prefix"
                 )
             ]
         )
-        spec = client.NetworkingV1beta1IngressSpec(
-            rules=[client.NetworkingV1beta1IngressRule(http=ingress_rule_value)]
+        spec = client.V1IngressSpec(
+            rules=[client.V1IngressRule(http=ingress_rule_value)]
         )
-        ingress = client.NetworkingV1beta1Ingress(
-            api_version="networking.k8s.io/v1beta1",
+        ingress = client.V1Ingress(
+            api_version="networking.k8s.io/v1",
             kind="Ingress",
             spec=spec,
             metadata=metadata,
@@ -306,7 +305,7 @@ def instantiate_chained_k8s_objects(kubernetes_objects, namespace):
     instantiate_k8s_object = {
         "deployment": current_k8s_appsv1_api_client.create_namespaced_deployment,
         "service": current_k8s_corev1_api_client.create_namespaced_service,
-        "ingress": current_k8s_networking_v1beta1.create_namespaced_ingress,
+        "ingress": current_k8s_networking_api_client.create_namespaced_ingress,
     }
     try:
         parent_k8s_object_references = None
@@ -331,7 +330,7 @@ def instantiate_chained_k8s_objects(kubernetes_objects, namespace):
     except ApiException as e:
         raise ApiException(
             "Exception when calling ExtensionsV1beta1Api->"
-            "create_namespaced_deployment_rollback: {}\n".format(e)
+            f"create_namespaced_deployment_rollback: {e}\n"
         )
 
 
@@ -346,7 +345,7 @@ def delete_k8s_objects_if_exist(kubernetes_objects, namespace):
     delete_k8s_object = {
         "deployment": current_k8s_appsv1_api_client.delete_namespaced_deployment,
         "service": current_k8s_corev1_api_client.delete_namespaced_service,
-        "ingress": current_k8s_networking_v1beta1.delete_namespaced_ingress,
+        "ingress": current_k8s_networking_api_client.delete_namespaced_ingress,
     }
     try:
         for obj in kubernetes_objects.items():
@@ -370,7 +369,7 @@ def delete_k8s_ingress_object(ingress_name, namespace):
     :param namespace: k8s namespace of ingress object.
     """
     try:
-        current_k8s_networking_v1beta1.delete_namespaced_ingress(
+        current_k8s_networking_api_client.delete_namespaced_ingress(
             name=ingress_name, namespace=namespace, body=client.V1DeleteOptions()
         )
     except ApiException as k8s_api_exception:

--- a/reana_workflow_controller/version.py
+++ b/reana_workflow_controller/version.py
@@ -14,4 +14,4 @@ This file is imported by ``reana_workflow_controller.__init__`` and parsed by
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.1"
+__version__ = "0.9.0a1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,9 +32,9 @@ jsonpointer==2.2          # via jsonschema
 jsonref==0.2              # via bravado-core
 jsonschema[format]==3.2.0  # via bravado-core, reana-commons, swagger-spec-validator
 kombu==5.2.3              # via reana-commons
-kubernetes==11.0.0        # via reana-commons
+kubernetes==22.6.0        # via reana-commons
 mako==1.1.6               # via alembic
-markupsafe==2.0.1         # via jinja2, mako
+markupsafe==2.0.1         # via jinja2, mako, reana-workflow-controller (setup.py)
 marshmallow==2.20.1       # via reana-workflow-controller (setup.py), webargs
 mock==3.0.5               # via reana-commons
 monotonic==1.6            # via bravado
@@ -51,8 +51,8 @@ pyrsistent==0.18.1        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core, kubernetes
 pytz==2021.3              # via bravado-core, fs
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.8.3  # via reana-db, reana-workflow-controller (setup.py)
-reana-db==0.8.1           # via reana-workflow-controller (setup.py)
+reana-commons[kubernetes]==0.9.0a2  # via reana-db, reana-workflow-controller (setup.py)
+reana-db==0.9.0a2         # via reana-workflow-controller (setup.py)
 requests-oauthlib==1.3.1  # via kubernetes
 requests==2.25.0          # via bravado, kubernetes, reana-workflow-controller (setup.py), requests-oauthlib
 rfc3987==1.3.8            # via jsonschema

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.8.1,<0.9.0",
+    "pytest-reana>=0.9.0a1,<0.10.0",
 ]
 
 extras_require = {
@@ -47,13 +47,14 @@ setup_requires = [
 
 install_requires = [
     "Flask>=1.0.4,<2.0",
+    "MarkupSafe>=2.0.0,<2.1.0",
     "Werkzeug>=1.0.1,<2.0",
     "gitpython>=2.1",
     "jsonpickle>=0.9.6",
     "marshmallow>2.13.0,<=2.20.1",
     "packaging>=18.0",
-    "reana-commons[kubernetes]>=0.8.3,<0.9.0",
-    "reana-db>=0.8.1,<0.9.0",
+    "reana-commons[kubernetes]>=0.9.0a2,<0.10.0",
+    "reana-db>=0.9.0a2,<0.10.0",
     "requests==2.25.0",
     "sqlalchemy-utils>=0.31.0",
     "uwsgi-tools>=1.1.1",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1374,7 +1374,7 @@ def test_create_interactive_session(app, default_user, sample_serial_workflow_in
         with mock.patch.multiple(
             "reana_workflow_controller.k8s",
             current_k8s_corev1_api_client=mock.DEFAULT,
-            current_k8s_networking_v1beta1=mock.DEFAULT,
+            current_k8s_networking_api_client=mock.DEFAULT,
             current_k8s_appsv1_api_client=mock.DEFAULT,
         ):
             res = client.post(
@@ -1416,7 +1416,7 @@ def test_create_interactive_session_custom_image(
         with mock.patch.multiple(
             "reana_workflow_controller.k8s",
             current_k8s_corev1_api_client=mock.DEFAULT,
-            current_k8s_networking_v1beta1=mock.DEFAULT,
+            current_k8s_networking_api_client=mock.DEFAULT,
             current_k8s_appsv1_api_client=mock.DEFAULT,
         ) as mocks:
             client.post(
@@ -1450,7 +1450,7 @@ def test_close_interactive_session(
     session.commit()
     with app.test_client() as client:
         with mock.patch(
-            "reana_workflow_controller.k8s" ".current_k8s_networking_v1beta1"
+            "reana_workflow_controller.k8s" ".current_k8s_networking_api_client"
         ):
             res = client.post(
                 url_for(

--- a/tests/test_workflow_run_manager.py
+++ b/tests/test_workflow_run_manager.py
@@ -24,7 +24,7 @@ def test_start_interactive_session(sample_serial_workflow_in_db):
     with patch.multiple(
         "reana_workflow_controller.k8s",
         current_k8s_corev1_api_client=DEFAULT,
-        current_k8s_networking_v1beta1=DEFAULT,
+        current_k8s_networking_api_client=DEFAULT,
         current_k8s_appsv1_api_client=DEFAULT,
     ) as mocks:
         kwrm = KubernetesWorkflowRunManager(sample_serial_workflow_in_db)
@@ -37,7 +37,7 @@ def test_start_interactive_session(sample_serial_workflow_in_db):
             "current_k8s_corev1_api_client"
         ].create_namespaced_service.assert_called_once()
         mocks[
-            "current_k8s_networking_v1beta1"
+            "current_k8s_networking_api_client"
         ].create_namespaced_ingress.assert_called_once()
 
 
@@ -51,7 +51,7 @@ def test_start_interactive_workflow_k8s_failure(sample_serial_workflow_in_db):
         "reana_workflow_controller.k8s",
         current_k8s_appsv1_api_client=mocked_k8s_client,
         current_k8s_corev1_api_client=DEFAULT,
-        current_k8s_networking_v1beta1=DEFAULT,
+        current_k8s_networking_api_client=DEFAULT,
     ):
         with pytest.raises(
             REANAInteractiveSessionError, match=r".*Kubernetes has failed.*"
@@ -78,7 +78,7 @@ def test_atomic_creation_of_interactive_session(sample_serial_workflow_in_db):
     with patch.multiple(
         "reana_workflow_controller.k8s",
         current_k8s_appsv1_api_client=mocked_k8s_client,
-        current_k8s_networking_v1beta1=DEFAULT,
+        current_k8s_networking_api_client=DEFAULT,
         current_k8s_corev1_api_client=DEFAULT,
     ) as mocks:
         try:
@@ -90,7 +90,7 @@ def test_atomic_creation_of_interactive_session(sample_serial_workflow_in_db):
                 "current_k8s_corev1_api_client"
             ].delete_namespaced_service.assert_called_once()
             mocks[
-                "current_k8s_networking_v1beta1"
+                "current_k8s_networking_api_client"
             ].delete_namespaced_ingress.assert_called_once()
             mocked_k8s_client.delete_namespaced_deployment.assert_called_once()
             assert not sample_serial_workflow_in_db.sessions.all()
@@ -124,7 +124,7 @@ def test_interactive_session_closure(sample_serial_workflow_in_db, session):
     with patch.multiple(
         "reana_workflow_controller.k8s",
         current_k8s_appsv1_api_client=mocked_k8s_client,
-        current_k8s_networking_v1beta1=DEFAULT,
+        current_k8s_networking_api_client=DEFAULT,
         current_k8s_corev1_api_client=DEFAULT,
     ):
         kwrm = KubernetesWorkflowRunManager(workflow)


### PR DESCRIPTION
closes https://github.com/reanahub/reana/issues/482

Tests are failing, most probably, because `reana-commons` is also updated.