### PR TITLE
consumer: set prefetch_count to limit received messages 

### DIFF
--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -48,6 +48,12 @@ SHARED_FS_MAPPING = {
 }
 """Mapping from the shared file system backend to the job file system."""
 
+REANA_JOB_STATUS_CONSUMER_PREFETCH_COUNT = int(
+    os.getenv("REANA_JOB_STATUS_CONSUMER_PREFETCH_COUNT", 200)
+)
+"""The value defines the max number of unacknowledged deliveries that are
+permitted on a ``jobs-status`` consumer."""
+
 REANA_WORKFLOW_ENGINE_IMAGE_CWL = os.getenv(
     "REANA_WORKFLOW_ENGINE_IMAGE_CWL", "reanahub/reana-workflow-engine-cwl:latest"
 )

--- a/reana_workflow_controller/consumer.py
+++ b/reana_workflow_controller/consumer.py
@@ -39,6 +39,7 @@ from reana_workflow_controller.config import (
     PROGRESS_STATUSES,
     REANA_GITLAB_URL,
     REANA_HOSTNAME,
+    REANA_JOB_STATUS_CONSUMER_PREFETCH_COUNT,
 )
 from reana_workflow_controller.errors import REANAWorkflowControllerError
 
@@ -64,6 +65,9 @@ class JobStatusConsumer(BaseConsumer):
                 queues=self.queue,
                 callbacks=[self.on_message],
                 accept=[self.message_default_format],
+                prefetch_count=REANA_JOB_STATUS_CONSUMER_PREFETCH_COUNT
+                if REANA_JOB_STATUS_CONSUMER_PREFETCH_COUNT
+                else None,
             )
         ]
 


### PR DESCRIPTION
closes https://github.com/reanahub/reana-server/issues/410

As described in https://github.com/reanahub/reana-commons/pull/314#issuecomment-954770879, by default messages in the queue may not spend any time at all and may be consumed straight away. In this case the priority queue will not get any opportunity to prioritize them. 

To illustrate with roofit example. Without the PR all the messages are sent to the consumer (unacked)
![Screenshot 2021-10-29 at 16-29-02 RabbitMQ Management](https://user-images.githubusercontent.com/4990025/139455046-c3381f2c-2a26-4b10-b6d5-6f8be88d830f.png)

With this PR only one message at a time is being processed in the consumer while the others wait in the queue (ready):
![Screenshot 2021-10-29 at 16-32-11 RabbitMQ Management](https://user-images.githubusercontent.com/4990025/139455276-1f4f54b4-09e4-434e-8906-cc443ecf8a74.png)

Please note that this setting can slow down the job status processing, so we should be careful with selecting the proper value. Perhaps the value should be increased after some initial tests are done.
