### PR TITLE
workflow_run_manager: propagate job controller connection check env to engines

### DIFF
--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -21,13 +21,13 @@ from reana_commons.config import (
     REANA_COMPONENT_PREFIX,
     REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE,
     REANA_JOB_HOSTPATH_MOUNTS,
+    REANA_JOB_CONTROLLER_CONNECTION_CHECK_SLEEP,
     REANA_RUNTIME_KUBERNETES_KEEP_ALIVE_JOBS_WITH_STATUSES,
     REANA_RUNTIME_KUBERNETES_NAMESPACE,
     REANA_RUNTIME_BATCH_KUBERNETES_NODE_LABEL,
     REANA_RUNTIME_JOBS_KUBERNETES_NODE_LABEL,
     REANA_RUNTIME_KUBERNETES_SERVICEACCOUNT_NAME,
     REANA_STORAGE_BACKEND,
-    SHARED_VOLUME_PATH,
     WORKFLOW_RUNTIME_USER_GID,
     WORKFLOW_RUNTIME_USER_NAME,
     WORKFLOW_RUNTIME_USER_UID,
@@ -44,19 +44,10 @@ from reana_commons.utils import (
 )
 from reana_db.config import SQLALCHEMY_DATABASE_URI
 from reana_db.database import Session
-from reana_db.models import (
-    Job,
-    JobStatus,
-    InteractiveSession,
-    InteractiveSessionType,
-    RunStatus,
-)
+from reana_db.models import Job, JobStatus, InteractiveSession, InteractiveSessionType
 
-from reana_workflow_controller.errors import (
-    REANAInteractiveSessionError,
-    REANAWorkflowControllerError,
-    REANAWorkflowStopError,
-)
+from reana_workflow_controller.errors import REANAInteractiveSessionError
+
 from reana_workflow_controller.k8s import (
     build_interactive_k8s_objects,
     delete_k8s_ingress_object,
@@ -72,7 +63,6 @@ from reana_workflow_controller.config import (  # isort:skip
     REANA_WORKFLOW_ENGINE_IMAGE_SERIAL,
     REANA_WORKFLOW_ENGINE_IMAGE_SNAKEMAKE,
     REANA_WORKFLOW_ENGINE_IMAGE_YADAGE,
-    SHARED_FS_MAPPING,
     WORKFLOW_ENGINE_COMMON_ENV_VARS,
     DEBUG_ENV_VARS,
 )
@@ -486,6 +476,10 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                 {
                     "name": "REANA_RUNTIME_KUBERNETES_NAMESPACE",
                     "value": REANA_RUNTIME_KUBERNETES_NAMESPACE,
+                },
+                {
+                    "name": "REANA_JOB_CONTROLLER_CONNECTION_CHECK_SLEEP",
+                    "value": str(REANA_JOB_CONTROLLER_CONNECTION_CHECK_SLEEP),
                 },
             ]
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ pyrsistent==0.18.0        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core, kubernetes
 pytz==2021.3              # via bravado-core, fs
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.8.0a34	# via reana-db, reana-workflow-controller (setup.py)
+reana-commons[kubernetes]==0.8.0a36	# via reana-db, reana-workflow-controller (setup.py)
 reana-db==0.8.0a22	# via reana-workflow-controller (setup.py)
 requests-oauthlib==1.3.0  # via kubernetes
 requests==2.20.0          # via bravado, kubernetes, reana-workflow-controller (setup.py), requests-oauthlib

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_requires = [
     "jsonpickle>=0.9.6",
     "marshmallow>2.13.0,<=2.20.1",
     "packaging>=18.0",
-    "reana-commons[kubernetes]>=0.8.0a34,<0.9.0",
+    "reana-commons[kubernetes]>=0.8.0a36,<0.9.0",
     "reana-db>=0.8.0a22,<0.9.0",
     "requests==2.20.0",
     "sqlalchemy-utils>=0.31.0",


### PR DESCRIPTION
closes https://github.com/reanahub/reana-commons/issues/301

To test:
- add `REANA_JOB_CONTROLLER_CONNECTION_CHECK_SLEEP: 5` [here](https://github.com/reanahub/reana/blob/master/helm/reana/values.yaml#L76)
- place wdb breakpoint and inspect `REANA_JOB_CONTROLLER_CONNECTION_CHECK_SLEEP` value [here](https://github.com/reanahub/reana-commons/blob/6d42f9c99d450bd52737959f40bc038fd77cb0fd/reana_commons/utils.py#L388)