### PR TITLE
consumer: fetch specific workflow pod during deletion

### DIFF
--- a/reana_workflow_controller/consumer.py
+++ b/reana_workflow_controller/consumer.py
@@ -267,6 +267,7 @@ def _delete_workflow_engine_pod(workflow):
     try:
         jobs = current_k8s_corev1_api_client.list_namespaced_pod(
             namespace=REANA_RUNTIME_KUBERNETES_NAMESPACE,
+            label_selector=f"reana-run-batch-workflow-uuid={str(workflow.id_)}",
         )
         for job in jobs.items:
             if str(workflow.id_) in job.metadata.name:

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -438,7 +438,10 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
 
         workflow_metadata = client.V1ObjectMeta(
             name=name,
-            labels={"reana_workflow_mode": "batch"},
+            labels={
+                "reana_workflow_mode": "batch",
+                "reana-run-batch-workflow-uuid": str(self.workflow.id_),
+            },
             namespace=REANA_RUNTIME_KUBERNETES_NAMESPACE,
         )
         job = client.V1Job()


### PR DESCRIPTION
closes https://github.com/reanahub/reana-job-controller/issues/326

Once the workflow finishes consumer tries to `_delete_workflow_engine_pod()`. Before it was fetching all available pods in the cluster via `current_k8s_corev1_api_client.list_namespaced_pod()` and iterating to find a specific pod to terminate. Now it will fetch the right pod using `label_selector` making it faster to terminate.