### PR TITLE
utils: optimize querying workflow progress information

### DIFF
--- a/reana_workflow_controller/rest/workflows.py
+++ b/reana_workflow_controller/rest/workflows.py
@@ -19,8 +19,6 @@ from reana_db.models import (
     User,
     Workflow,
     RunStatus,
-    InteractiveSession,
-    WorkflowSession,
 )
 from reana_db.utils import _get_workflow_with_uuid_or_name
 

--- a/reana_workflow_controller/rest/workflows_status.py
+++ b/reana_workflow_controller/rest/workflows_status.py
@@ -23,7 +23,6 @@ from reana_workflow_controller.errors import (
 from reana_workflow_controller.rest.utils import (
     build_workflow_logs,
     delete_workflow,
-    get_current_job_progress,
     get_workflow_name,
     get_workflow_progress,
     start_workflow,


### PR DESCRIPTION
- Only query progress information when `include_progress` is set
- Optimize querying the most recent job info

closes #415
closes #416