### PR TITLE
setup: upgrade `requests` to fix `urrlib3` vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, reana-commons
 reana-commons[kubernetes]==0.8.0a36	# via reana-db, reana-workflow-controller (setup.py)
 reana-db==0.8.0a22	# via reana-workflow-controller (setup.py)
 requests-oauthlib==1.3.0  # via kubernetes
-requests==2.20.0          # via bravado, kubernetes, reana-workflow-controller (setup.py), requests-oauthlib
+requests==2.25.0          # via bravado, kubernetes, reana-workflow-controller (setup.py), requests-oauthlib
 rfc3987==1.3.8            # via jsonschema
 rsa==4.7.2                # via google-auth
 simplejson==3.17.5        # via bravado, bravado-core
@@ -65,7 +65,7 @@ sqlalchemy==1.3.24        # via alembic, reana-db, sqlalchemy-utils
 strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==2.7.3  # via bravado-core
 typing-extensions==3.10.0.2  # via bravado, gitpython
-urllib3==1.24.3           # via kubernetes, requests
+urllib3==1.26.7           # via kubernetes, requests
 uwsgi-tools==1.1.1        # via reana-workflow-controller (setup.py)
 uwsgi==2.0.20             # via reana-workflow-controller (setup.py)
 uwsgitop==0.11            # via reana-workflow-controller (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_requires = [
     "packaging>=18.0",
     "reana-commons[kubernetes]>=0.8.0a36,<0.9.0",
     "reana-db>=0.8.0a22,<0.9.0",
-    "requests==2.20.0",
+    "requests==2.25.0",
     "sqlalchemy-utils>=0.31.0",
     "uwsgi-tools>=1.1.1",
     "uWSGI>=2.0.17",


### PR DESCRIPTION
https://github.com/reanahub/reana-workflow-controller/security/dependabot/requirements.txt/urllib3/open

`requests` [2.25.0](https://github.com/psf/requests/blob/03957eb1c2b9a1e5e6d61f5e930d7c5ed7cfe853/setup.py#L47) vs [2.24.0](https://github.com/psf/requests/blob/0797c61fd541f92f66e409dbf9515ca287af28d2/setup.py#L47), recommended to upgrade to `urllib3>=1.26.5`