### PR TITLE
api: add a new line for generated openapi specs

### DIFF
--- a/scripts/generate_openapi_spec.py
+++ b/scripts/generate_openapi_spec.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -83,7 +83,7 @@ def build_openapi_spec(publish):
         atomic=False,
     ) as output_file:
 
-        output_file.write(spec_json)
+        output_file.write(spec_json + "\n")
 
         click.echo(
             click.style(


### PR DESCRIPTION
closes https://github.com/reanahub/reana-workflow-controller/issues/424

Adds a new line to generated openAPI specs to solve a problem as described in https://github.com/reanahub/reana-commons/pull/330#discussion_r794438980