### PR TITLE
rest: update disk usage after workspace deletion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 0.9.0 (UNRELEASED)
 - Adds support for Kubernetes networking/v1 API to interactive sessions.
 - Changes workflow list endpoint to add the possibility to filter by workflow id.
 - Changes default consumer prefetch count to handle 10 messages instead of 200 in order to reduce the probability of 406 PRECONDITION errors on message acknowledgement.
+- Changes the workflow status endpoint to update the disk quota usage when a workspace is deleted.
 
 Version 0.8.1 (2022-02-07)
 ---------------------------


### PR DESCRIPTION
Closes reanahub/reana-ui#259
Depends on reanahub/reana-db#168

How to test:
Trying different combinations of `disk` and `cpu` in `WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY`
1. Launch some workflows
2. Simulate a periodic quota update
```
kubectl create job --from cronjob/reana-resource-quota-update manual-quota-update-001
```
3. Delete one of the workflows, together with its workspace

Expected result: The disk quota is updated immediately after the deletion of a workspace, even if `disk` is not in `WORKFLOW_TERMINATION_QUOTA_UPDATE_POLICY`