### PR TITLE
rest: change default mime type for files download

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1382,7 +1382,11 @@
           }
         ],
         "produces": [
-          "multipart/form-data"
+          "application/octet-stream",
+          "application/json",
+          "application/zip",
+          "image/*",
+          "text/html"
         ],
         "responses": {
           "200": {

--- a/reana_workflow_controller/rest/utils.py
+++ b/reana_workflow_controller/rest/utils.py
@@ -583,7 +583,7 @@ def download_files_recursive_wildcard(workflow_name, workspace_path, path):
 
     def _send_single_file(absolute_file_path: str, workspace_path: str):
         """Send single file from directory to the client."""
-        default_response_mime_type = "multipart/form-data"
+        default_response_mime_type = "application/octet-stream"
         preview = json.loads(request.args.get("preview", "false").lower())
         response_mime_type = default_response_mime_type
         file_mime_type = get_previewable_mime_type(path)

--- a/reana_workflow_controller/rest/workflows_workspace.py
+++ b/reana_workflow_controller/rest/workflows_workspace.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021 CERN.
+# Copyright (C) 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -195,7 +195,11 @@ def download_file(workflow_id_or_name, file_name):  # noqa
         inside the workspace to return its content.
       operationId: download_file
       produces:
-        - multipart/form-data
+        - application/octet-stream
+        - application/json
+        - application/zip
+        - image/*
+        - text/html
       parameters:
         - name: user
           in: query


### PR DESCRIPTION
Changes the default MIME type used when downloading files to `application/octet-stream`.
Previously, `multipart/form-data` was used but the response was not correctly encoded as such.

Closes reanahub/reana-server#418

How to reproduce the issue:
1. Launch `reana-demo-helloworld`
2. Preview the file `data/names.txt`
3. Check the logs of reana-server

Expected result: the warning is not present anymore in reana-server's logs