### PR TITLE
rest: allow starting workflows without retention rules

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -284,7 +284,6 @@
                     "title": "Retention rule for the files in the workspace.",
                     "type": "object"
                   },
-                  "minItems": 1,
                   "title": "Retention rules list for the files in the workspace.",
                   "type": "array"
                 },

--- a/reana_workflow_controller/rest/workflows.py
+++ b/reana_workflow_controller/rest/workflows.py
@@ -378,7 +378,6 @@ def create_workflow():  # noqa
               retention_rules:
                 type: array
                 title: Retention rules list for the files in the workspace.
-                minItems: 1
                 items:
                   title: Retention rule for the files in the workspace.
                   type: object


### PR DESCRIPTION
After reanahub/reana-server#528, it can happen that workflows do not
have any retention rules.

Closes reanahub/reana#653