### PR TITLE
rest: respect user when deleting all workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -34,7 +34,7 @@ jobs:
       - name: Check Python code formatting
         run: |
           pip install --upgrade pip
-          pip install black==19.10b0
+          pip install black==19.10b0 click==7.1.2
           ./run-tests.sh --check-black
 
   lint-flake8:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.8.2 (2022-10-06)
+---------------------------
+
+- Fixes ``delete --include-all-runs`` functionality to delete only workflow owner's past runs.
+
 Version 0.8.1 (2022-02-07)
 ---------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "description": "Submit and manage workflows",
     "title": "REANA Workflow Controller",
-    "version": "0.8.1"
+    "version": "0.8.2"
   },
   "parameters": {},
   "paths": {

--- a/reana_workflow_controller/rest/utils.py
+++ b/reana_workflow_controller/rest/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2020, 2021 CERN.
+# Copyright (C) 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -206,6 +206,7 @@ def delete_workflow(workflow, all_runs=False, workspace=False):
                     Session.query(Workflow)
                     .filter(
                         Workflow.name == workflow.name,
+                        Workflow.owner_id == workflow.owner_id,
                         Workflow.status != RunStatus.running,
                     )
                     .all()

--- a/reana_workflow_controller/version.py
+++ b/reana_workflow_controller/version.py
@@ -14,4 +14,4 @@ This file is imported by ``reana_workflow_controller.__init__`` and parsed by
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,11 @@ setup_requires = [
 
 install_requires = [
     "Flask>=1.0.4,<2.0",
+    "click>=7.1.2,<8.1",
     "Werkzeug>=1.0.1,<2.0",
     "gitpython>=2.1",
     "jsonpickle>=0.9.6",
+    "markupsafe>=2.0.1,<2.1.0",
     "marshmallow>2.13.0,<=2.20.1",
     "packaging>=18.0",
     "reana-commons[kubernetes]>=0.8.3,<0.9.0",


### PR DESCRIPTION
Fixes a problem when calling `delete --include-all-runs` could have deleting other person's workflows by simple name matching.