### PR TITLE
k8s: update interactive sessions spec to include labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.9.1 (UNRELEASED)
 --------------------------
 
 - Changes the deletion of a workflow to automatically delete an open interactive session attached to its workspace.
+- Changes the k8s specification for interactive session pods to include labels for improved subset selection of objects.
 
 Version 0.9.0 (2023-01-19)
 --------------------------

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -315,6 +315,8 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                 access_path,
                 access_token=self.workflow.get_owner_access_token(),
                 cvmfs_repos=self.retrieve_required_cvmfs_repos(),
+                owner_id=self.workflow.owner_id,
+                workflow_id=self.workflow.id_,
                 **kwargs,
             )
 


### PR DESCRIPTION
Add new labels for workflow_id, owner_id and workflow_mode for improved subset selection of objects and metadata parsing from the pod specification.

closes https://github.com/reanahub/reana-workflow-controller/issues/498