### PR TITLE
uwsgi: fix memory consumption related to max-fd

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 0.9.1 (UNRELEASED)
 - Changes the deletion of a workflow to automatically delete an open interactive session attached to its workspace.
 - Changes the k8s specification for interactive session pods to include labels for improved subset selection of objects.
 - Changes the k8s specification for interactive session ingress resource to include annotations.
+- Fixes uWSGI memory consumption on systems with very high allowed number of open files.
 
 Version 0.9.0 (2023-01-19)
 --------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 0.9.1 (UNRELEASED)
 - Changes the deletion of a workflow to automatically delete an open interactive session attached to its workspace.
 - Changes the k8s specification for interactive session pods to include labels for improved subset selection of objects.
 - Changes the k8s specification for interactive session ingress resource to include annotations.
+- Changes uWSGI configuration to increase buffer size, add vacuum option, etc.
 - Fixes uWSGI memory consumption on systems with very high allowed number of open files.
 
 Version 0.9.0 (2023-01-19)

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,11 +50,15 @@ RUN if test -e modules/reana-db; then pip install -e modules/reana-db --upgrade;
 RUN pip check
 
 # Set useful environment variables
+ARG UWSGI_BUFFER_SIZE=8192
+ARG UWSGI_MAX_FD=1048576
 ARG UWSGI_PROCESSES=2
 ARG UWSGI_THREADS=2
 ENV FLASK_APP=reana_workflow_controller/app.py \
     PYTHONPATH=/workdir \
     TERM=xterm \
+    UWSGI_BUFFER_SIZE=${UWSGI_BUFFER_SIZE:-8192} \
+    UWSGI_MAX_FD=${UWSGI_MAX_FD:-1048576} \
     UWSGI_PROCESSES=${UWSGI_PROCESSES:-2} \
     UWSGI_THREADS=${UWSGI_THREADS:-2}
 
@@ -64,11 +68,17 @@ EXPOSE 5000
 # Run server
 # hadolint ignore=DL3025
 CMD uwsgi \
+    --buffer-size ${UWSGI_BUFFER_SIZE} \
+    --die-on-term \
+    --enable-threads \
     --http-socket 0.0.0.0:5000 \
     --master \
-    --max-fd 1048576 \
+    --max-fd ${UWSGI_MAX_FD} \
     --module reana_workflow_controller.app:app \
+    --need-app \
     --processes ${UWSGI_PROCESSES} \
+    --single-interpreter \
     --stats /tmp/stats.socket \
     --threads ${UWSGI_THREADS} \
+    --vacuum \
     --wsgi-disable-file-wrapper

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,12 @@ EXPOSE 5000
 
 # Run server
 # hadolint ignore=DL3025
-CMD uwsgi --module reana_workflow_controller.app:app \
-    --http-socket 0.0.0.0:5000 --master \
-    --processes ${UWSGI_PROCESSES} --threads ${UWSGI_THREADS} \
+CMD uwsgi \
+    --http-socket 0.0.0.0:5000 \
+    --master \
+    --max-fd 1048576 \
+    --module reana_workflow_controller.app:app \
+    --processes ${UWSGI_PROCESSES} \
     --stats /tmp/stats.socket \
+    --threads ${UWSGI_THREADS} \
     --wsgi-disable-file-wrapper

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
+Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "reana"
-copyright = "2017-2020 info@reana.io"
+copyright = "2017-2023 info@reana.io"
 author = "info@reana.io"
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Fixes possible memory consumption trouble on systems like Fedora 37 that use very high file descriptor limits (`fs.nr_open = 1073741816`). See <https://github.com/reanahub/reana/pull/703> for the full explanation.