### PR TITLE
workflow_run_manager: update stopped jobs in the DB

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Version 0.9.1 (UNRELEASED)
 - Changes the k8s specification for interactive session pods to include labels for improved subset selection of objects.
 - Changes the k8s specification for interactive session ingress resource to include annotations.
 - Changes uWSGI configuration to increase buffer size, add vacuum option, etc.
+- Fixes job status inconsistency by correctly setting running jobs' status to ``stopped`` when a workflow is stopped.
 - Fixes uWSGI memory consumption on systems with very high allowed number of open files.
 
 Version 0.9.0 (2023-01-19)


### PR DESCRIPTION
Mark the previously running jobs of a stopped workflow as `stopped` in
the database.

Closes reanahub/reana-job-controller#394.
