### PR TITLE
global: update to apispec v3

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,11 +1,9 @@
 {
-  "definitions": {},
   "info": {
     "description": "Submit and manage workflows",
     "title": "REANA Workflow Controller",
     "version": "0.9.1a2"
   },
-  "parameters": {},
   "paths": {
     "/api/workflows": {
       "get": {
@@ -1550,6 +1548,5 @@
       }
     }
   },
-  "swagger": "2.0",
-  "tags": []
+  "swagger": "2.0"
 }

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -232,7 +232,7 @@ class WorkflowRunManager:
             ]
         )
         cvmfs_volumes = self.retrieve_required_cvmfs_repos() or "false"
-        if type(cvmfs_volumes) == list:
+        if isinstance(cvmfs_volumes, list):
             cvmfs_env_var = {"name": "REANA_MOUNT_CVMFS", "value": str(cvmfs_volumes)}
             env_vars.append(cvmfs_env_var)
             for cvmfs_volume in cvmfs_volumes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ pyrsistent==0.19.3        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core, kubernetes
 pytz==2022.7.1            # via bravado-core
 pyyaml==5.4.1             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.9.3a3	# via reana-db, reana-workflow-controller (setup.py)
+reana-commons[kubernetes]==0.9.3a4	# via reana-db, reana-workflow-controller (setup.py)
 reana-db==0.9.1	# via reana-workflow-controller (setup.py)
 requests-oauthlib==1.3.1  # via kubernetes
 requests==2.25.0          # via bravado, bravado-core, kubernetes, reana-workflow-controller (setup.py), requests-oauthlib

--- a/scripts/generate_openapi_spec.py
+++ b/scripts/generate_openapi_spec.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020, 2021, 2022 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,6 +14,7 @@ import os
 
 import click
 from apispec import APISpec
+from apispec_webframeworks.flask import FlaskPlugin
 from flask import current_app
 from flask.cli import with_appcontext
 from reana_commons.utils import copy_openapi_specs
@@ -57,8 +58,9 @@ def build_openapi_spec(publish):
     spec = APISpec(
         title=package,
         version=ver,
+        openapi_version="2.0",
         info=dict(description=desc),
-        plugins=("apispec.ext.flask",),
+        plugins=(FlaskPlugin(),),
     )
 
     # Add marshmallow schemas to the specification here
@@ -67,7 +69,7 @@ def build_openapi_spec(publish):
     # Collect OpenAPI docstrings from Flask endpoints
     for key in current_app.view_functions:
         if key != "static" and key != "get_openapi_spec":
-            spec.add_path(view=current_app.view_functions[key])
+            spec.path(view=current_app.view_functions[key])
 
     spec_json = json.dumps(
         spec.to_dict(), indent=2, separators=(",", ": "), sort_keys=True

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 
 tests_require = [
-    "pytest-reana>=0.9.0,<0.10.0",
+    "pytest-reana>=0.9.1a1,<0.10.0",
 ]
 
 extras_require = {
@@ -55,7 +55,7 @@ install_requires = [
     "jsonpickle>=0.9.6",
     "marshmallow>2.13.0,<=2.20.1",
     "packaging>=18.0",
-    "reana-commons[kubernetes]>=0.9.3a3,<0.10.0",
+    "reana-commons[kubernetes]>=0.9.3a4,<0.10.0",
     "reana-db>=0.9.1,<0.10.0",
     "requests==2.25.0",
     "sqlalchemy-utils>=0.31.0",


### PR DESCRIPTION
Update to apispec v3, as the version used before is not compatible with
PyYAML v6.

Closes reanahub/reana-commons#399
