### PR TITLE
utils: return different message when deleting all the workflow runs

### DIFF
--- a/reana_workflow_controller/rest/utils.py
+++ b/reana_workflow_controller/rest/utils.py
@@ -270,10 +270,16 @@ def delete_workflow(workflow, all_runs=False, workspace=False):
                 _mark_workflow_as_deleted_in_db(workflow)
                 remove_workflow_jobs_from_cache(workflow)
 
+            if all_runs:
+                message = "All workflows named {0} successfully deleted.".format(
+                    workflow.name
+                )
+            else:
+                message = "Workflow successfully deleted."
             return (
                 jsonify(
                     {
-                        "message": "Workflow successfully deleted",
+                        "message": message,
                         "workflow_id": workflow.id_,
                         "workflow_name": get_workflow_name(workflow),
                         "status": workflow.status.name,

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup_requires = [
 
 install_requires = [
     "Flask>=2.1.1,<2.2.0",
-    "Werkzeug>=2.1.0",
+    "Werkzeug>=2.1.0,<3.0.0",
     "gitpython>=2.1",
     "jsonpickle>=0.9.6",
     "marshmallow>2.13.0,<=2.20.1",


### PR DESCRIPTION
Change the `delete_workflow` function so that when the deletion of a
workflow includes all its runs, then this is mentioned in the `message`
property returned.

Closes #531.
