### PR TITLE
tests: allow execution of selected pytests only

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -85,6 +85,7 @@ check_sphinx () {
 check_pytest () {
     clean_old_db_container
     start_db_container
+    trap clean_old_db_container SIGINT SIGTERM SIGSEGV ERR
     python setup.py test
     stop_db_container
 }


### PR DESCRIPTION
Allows execution of selected pytests via PYTESTCMD environment variable. Example: `PYTESTARG="-k test_version" ./run-tests.sh --check-pytest`.

Cleans up running DB container when some pytest segfaults.

Closes reanahub/reana#755.