### PR TITLE
rest: add sharing parameters to `get_workflows`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,6 +7,7 @@ The list of contributors in alphabetical order:
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
 - `Anton Khodak <https://orcid.org/0000-0003-3263-4553>`_
 - `Camila Diaz <https://orcid.org/0000-0001-5543-797X>`_
+- `Daan Rosendal <https://orcid.org/0000-0002-3447-9000>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_
 - `Dinos Kousidis <https://orcid.org/0000-0002-4914-4289>`_
 - `Harri Hirvonsalo <https://orcid.org/0000-0002-5503-510X>`_

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -993,6 +993,197 @@
         "summary": "Get the retention rules of a workflow."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/share": {
+      "post": {
+        "description": "This resource allows to share a workflow with other users.",
+        "operationId": "share_workflow",
+        "parameters": [
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Analysis UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. User to share the workflow with.",
+            "in": "query",
+            "name": "user_email_to_share_with",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Optional. Message to include when sharing the workflow.",
+            "in": "query",
+            "name": "message",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Optional. Date when access to the workflow will expire (format YYYY-MM-DD).",
+            "in": "query",
+            "name": "valid_until",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The workflow has been shared with the user.",
+            "examples": {
+              "application/json": {
+                "message": "The workflow has been shared with the user.",
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Missing data for required field."
+                ],
+                "message": "Malformed request."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. User is not allowed to share the workflow.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "User is not allowed to share the workflow."
+                ]
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist or user does not exist.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+                ],
+                "message": "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "409": {
+            "description": "Request failed. The workflow is already shared with the user.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "The workflow is already shared with the user."
+                ],
+                "message": "The workflow is already shared with the user."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Internal controller error."
+                ],
+                "message": "Internal controller error."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Share a workflow with other users."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/status": {
       "get": {
         "description": "This resource reports the status of workflow.",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1184,6 +1184,139 @@
         "summary": "Share a workflow with other users."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/share-status": {
+      "get": {
+        "description": "This resource returns the share status of a given workflow.",
+        "operationId": "get_workflow_share_status",
+        "parameters": [
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Workflow UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The response contains the share status of the workflow.",
+            "examples": {
+              "application/json": {
+                "shared_with": [
+                  {
+                    "user_email": "bob@example.org",
+                    "valid_until": "2022-11-24T23:59:59"
+                  }
+                ],
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "shared_with": {
+                  "items": {
+                    "properties": {
+                      "user_email": {
+                        "type": "string"
+                      },
+                      "valid_until": {
+                        "type": "string",
+                        "x-nullable": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Request failed. User not signed in.",
+            "examples": {
+              "application/json": {
+                "message": "User not signed in."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. Credentials are invalid or revoked.",
+            "examples": {
+              "application/json": {
+                "message": "Token not valid."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist.",
+            "examples": {
+              "application/json": {
+                "message": "Workflow mytest.1 does not exist."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal server error.",
+            "examples": {
+              "application/json": {
+                "message": "Something went wrong."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Get the share status of a workflow."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/status": {
       "get": {
         "description": "This resource reports the status of workflow.",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -89,6 +89,27 @@
             "name": "workflow_id_or_name",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "Optional flag to list all shared (owned and unowned) workflows.",
+            "in": "query",
+            "name": "shared",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "description": "Optional argument to list workflows shared by the specified user(s).",
+            "in": "query",
+            "name": "shared_by",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Optional argument to list workflows shared with the specified user(s).",
+            "in": "query",
+            "name": "shared_with",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -167,8 +188,14 @@
                       "name": {
                         "type": "string"
                       },
+                      "owner_email": {
+                        "type": "string"
+                      },
                       "progress": {
                         "type": "object"
+                      },
+                      "shared_with": {
+                        "type": "string"
                       },
                       "size": {
                         "properties": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1418,6 +1418,183 @@
         "summary": "Set workflow status."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/unshare": {
+      "post": {
+        "description": "This resource allows to unshare a workflow with other users.",
+        "operationId": "unshare_workflow",
+        "parameters": [
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Analysis UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. User to unshare the workflow with.",
+            "in": "query",
+            "name": "user_email_to_unshare_with",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The workflow has been unshared with the user.",
+            "examples": {
+              "application/json": {
+                "message": "The workflow has been unsahred with the user.",
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Missing data for required field."
+                ],
+                "message": "Malformed request."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. User is not allowed to unshare the workflow.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "User is not allowed to unshare the workflow."
+                ]
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist or user does not exist.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+                ],
+                "message": "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "409": {
+            "description": "Request failed. The workflow is not shared with the user.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "The workflow is not shared with the user."
+                ],
+                "message": "The workflow is not shared with the user."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Internal controller error."
+                ],
+                "message": "Internal controller error."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Unshare a workflow with other users."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/workspace": {
       "get": {
         "description": "This resource retrieves the file list of a workspace, given its workflow UUID.",

--- a/reana_workflow_controller/rest/workflows.py
+++ b/reana_workflow_controller/rest/workflows.py
@@ -13,13 +13,14 @@ import json
 import logging
 import re
 from typing import Optional
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from flask import Blueprint, jsonify, request
 from reana_commons.config import WORKFLOW_TIME_FORMAT
 from reana_db.database import Session
 from reana_db.models import RunStatus, User, UserWorkflow, Workflow, WorkflowResource
 from reana_db.utils import (
+    _get_workflow_by_uuid,
     _get_workflow_with_uuid_or_name,
     build_workspace_path,
     get_default_quota_resource,
@@ -64,6 +65,9 @@ blueprint = Blueprint("workflows", __name__)
         "user": fields.String(required=True),
         "verbose": fields.Bool(missing=False),
         "workflow_id_or_name": fields.String(),
+        "shared": fields.Bool(missing=False),
+        "shared_by": fields.String(),
+        "shared_with": fields.DelimitedList(fields.String()),
     },
     location="query",
 )
@@ -138,6 +142,21 @@ def get_workflows(args, paginate=None):  # noqa
           description: Optional analysis UUID or name to filter.
           required: false
           type: string
+        - name: shared
+          in: query
+          description: Optional flag to list all shared (owned and unowned) workflows.
+          required: false
+          type: boolean
+        - name: shared_by
+          in: query
+          description: Optional argument to list workflows shared by the specified user(s).
+          required: false
+          type: string
+        - name: shared_with
+          in: query
+          description: Optional argument to list workflows shared with the specified user(s).
+          required: false
+          type: string
       responses:
         200:
           description: >-
@@ -175,6 +194,10 @@ def get_workflows(args, paginate=None):  # noqa
                     launcher_url:
                       type: string
                       x-nullable: true
+                    owner_email:
+                        type: string
+                    shared_with:
+                        type: string
           examples:
             application/json:
               [
@@ -258,14 +281,90 @@ def get_workflows(args, paginate=None):  # noqa
     include_progress: bool = args.get("include_progress", verbose)
     include_workspace_size: bool = args.get("include_workspace_size", verbose)
     workflow_id_or_name: Optional[str] = args.get("workflow_id_or_name")
+    shared: bool = args.get("shared")
+    shared_by: Optional[str] = args.get("shared_by")
+    shared_with: Optional[str] = args.get("shared_with")
 
     try:
+        if shared_by and shared_with:
+            return (
+                jsonify(
+                    {
+                        "message": "You cannot filter by shared_by and shared_with at the same time."
+                    }
+                ),
+                400,
+            )
+
         user = User.query.filter(User.id_ == user_uuid).first()
         if not user:
             return jsonify({"message": "User {} does not exist".format(user_uuid)}), 404
 
         workflows = []
-        query = user.workflows
+
+        if not shared and not shared_with and not shared_by:
+            # default case: retrieve owned workflows
+            query = user.workflows
+        else:
+            if shared or shared_by:
+                # retrieve owned workflows and unowned workflows shared by others
+                workflows_shared_with_user = Session.query(
+                    user.shared_workflows.subquery().c.id_
+                )
+                query = Session.query(Workflow).filter(
+                    or_(
+                        Workflow.owner_id == user.id_,
+                        Workflow.id_.in_(workflows_shared_with_user),
+                    )
+                )
+            if shared_by and not shared:
+                if shared_by == "anybody":
+                    # retrieve unowned workflows shared by anyone
+                    query = query.filter(Workflow.id_.in_(workflows_shared_with_user))
+                else:
+                    # retrieve unowned workflows shared by specific user
+                    shared_by_user = (
+                        Session.query(User).filter(User.email == shared_by).first()
+                    )
+                    if not shared_by_user:
+                        return (
+                            jsonify(
+                                {
+                                    "message": f"User with email '{shared_by}' does not exist."
+                                }
+                            ),
+                            404,
+                        )
+                    query = query.filter(Workflow.owner_id == shared_by_user.id_)
+            if shared_with:
+                # starting point: retrieve owned workflows
+                query = user.workflows
+
+                first_shared_with = shared_with[0]
+                workflows_shared_by_user = Session.query(Workflow.id_).join(
+                    UserWorkflow,
+                    and_(
+                        Workflow.id_ == UserWorkflow.workflow_id,
+                        Workflow.owner_id == user.id_,
+                    ),
+                )
+
+                if first_shared_with == "nobody":
+                    # retrieve owned unshared workflows
+                    query = query.filter(Workflow.id_.notin_(workflows_shared_by_user))
+                elif first_shared_with == "anybody":
+                    # retrieve exclusively owned shared workflows
+                    query = query.filter(Workflow.id_.in_(workflows_shared_by_user))
+                else:
+                    # retrieve owned workflows shared with specific users
+                    shared_with_users = Session.query(User.id_).filter(
+                        User.email.in_(shared_with)
+                    )
+                    shared_with_workflows_ids = Session.query(
+                        UserWorkflow.workflow_id
+                    ).filter(UserWorkflow.user_id.in_(shared_with_users))
+                    query = query.filter(Workflow.id_.in_(shared_with_workflows_ids))
+
         if search:
             search = json.loads(search)
             search_val = search.get("name")[0]
@@ -295,7 +394,38 @@ def get_workflows(args, paginate=None):  # noqa
         elif sort in ["asc", "desc"]:
             column_sorted = getattr(Workflow.created, sort)()
         pagination_dict = paginate(query.order_by(column_sorted))
+
+        owner_ids = {workflow.owner_id for workflow in pagination_dict["items"]}
+        owners = dict(
+            Session.query(User.id_, User.email).filter(User.id_.in_(owner_ids)).all()
+        )
+
         for workflow in pagination_dict["items"]:
+            owner_email = owners.get(workflow.owner_id, "-")
+
+            if owner_email == user.email:
+                owner_email = "-"
+
+            if shared or shared_with:
+                shared_with_users = (
+                    Session.query(User.email)
+                    .join(
+                        UserWorkflow,
+                        and_(
+                            User.id_ == UserWorkflow.user_id,
+                            UserWorkflow.workflow_id == workflow.id_,
+                        ),
+                    )
+                    .all()
+                )
+            else:
+                shared_with_users = None
+
+            if shared_with_users and owner_email == "-":
+                shared_with_emails = [user[0] for user in shared_with_users]
+            else:
+                shared_with_emails = "-"
+
             workflow_response = {
                 "id": workflow.id_,
                 "name": get_workflow_name(workflow),
@@ -306,6 +436,10 @@ def get_workflows(args, paginate=None):  # noqa
                 "progress": get_workflow_progress(
                     workflow, include_progress=include_progress
                 ),
+                "owner_email": owner_email,
+                "shared_with": ",".join(shared_with_emails)
+                if shared_with_emails != "-"
+                else "-",
             }
             if type_ == "interactive" or verbose:
                 int_session = workflow.sessions.first()
@@ -1106,7 +1240,7 @@ def share_workflow(
                 "Message is too long. Please keep it under 5000 characters."
             )
 
-        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, str(user_id))
+        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_id)
 
         existing_share = (
             Session.query(UserWorkflow)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,8 +7,8 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 """REANA-Workflow-Controller utility tests."""
 
-import os
 import json
+import os
 import stat
 import uuid
 from contextlib import nullcontext as does_not_raise
@@ -18,12 +18,12 @@ from typing import ContextManager
 import mock
 import pytest
 from reana_db.models import (
+    InteractiveSession,
+    InteractiveSessionType,
     Job,
     JobCache,
     RunStatus,
     Workflow,
-    InteractiveSession,
-    InteractiveSessionType,
 )
 from reana_db.utils import (
     get_disk_usage_or_zero,
@@ -53,9 +53,7 @@ from reana_workflow_controller.rest.utils import (
         pytest.param(RunStatus.running, marks=pytest.mark.xfail(strict=True)),
     ],
 )
-def test_delete_workflow(
-    app, session, default_user, sample_yadage_workflow_in_db, status
-):
+def test_delete_workflow(app, session, user0, sample_yadage_workflow_in_db, status):
     """Test deletion of a workflow in all possible statuses."""
     sample_yadage_workflow_in_db.status = status
     session.add(sample_yadage_workflow_in_db)
@@ -65,16 +63,14 @@ def test_delete_workflow(
     assert sample_yadage_workflow_in_db.status == RunStatus.deleted
 
 
-def test_delete_all_workflow_runs(
-    app, session, default_user, yadage_workflow_with_name
-):
+def test_delete_all_workflow_runs(app, session, user0, yadage_workflow_with_name):
     """Test deletion of all runs of a given workflow."""
     # add 5 workflows in the database with the same name
     for i in range(5):
         workflow = Workflow(
             id_=uuid.uuid4(),
             name=yadage_workflow_with_name["name"],
-            owner_id=default_user.id_,
+            owner_id=user0.id_,
             reana_specification=yadage_workflow_with_name["reana_specification"],
             operational_options={},
             type_=yadage_workflow_with_name["reana_specification"]["workflow"]["type"],
@@ -138,7 +134,7 @@ def test_workspace_deletion(
     mock_update_workflow_quota,
     app,
     session,
-    default_user,
+    user0,
     sample_yadage_workflow_in_db,
     workspace,
 ):
@@ -206,7 +202,7 @@ def test_workspace_deletion(
 
 
 def test_deletion_of_workspace_of_an_already_deleted_workflow(
-    app, session, default_user, sample_yadage_workflow_in_db
+    app, session, user0, sample_yadage_workflow_in_db
 ):
     """Test workspace deletion of an already deleted workflow."""
     create_workflow_workspace(sample_yadage_workflow_in_db.workspace_path)
@@ -272,7 +268,7 @@ def test_list_recursive_wildcard(tmp_shared_volume_path):
 
 
 def test_workspace_permissions(
-    app, session, default_user, sample_yadage_workflow_in_db, tmp_shared_volume_path
+    app, session, user0, sample_yadage_workflow_in_db, tmp_shared_volume_path
 ):
     """Test workspace dir permissions."""
     create_workflow_workspace(sample_yadage_workflow_in_db.workspace_path)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2268,3 +2268,121 @@ def test_unshare_workflow_with_message_and_valid_until(
         assert (
             response_data["message"] == "The workflow has been unshared with the user."
         )
+
+
+def test_get_workflow_share_status(
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
+):
+    """Test get_workflow_share_status."""
+    workflow = sample_serial_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # share workflow
+        client.post(
+            url_for(
+                "workflows.share_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
+            },
+        )
+        # get workflow share status
+        res = client.get(
+            url_for(
+                "workflows.get_workflow_share_status",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_check": user2.email,
+            },
+        )
+        assert res.status_code == 200
+        response_data = res.get_json()
+        assert response_data["shared_with"][0]["user_email"] == "user2@reana.io"
+
+
+def test_get_workflow_share_status_not_shared(
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
+):
+    """Test get_workflow_share_status for a workflow that is not shared."""
+    workflow = sample_serial_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # get workflow share status
+        res = client.get(
+            url_for(
+                "workflows.get_workflow_share_status",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+            },
+        )
+        assert res.status_code == 200
+        response_data = res.get_json()
+        assert response_data["shared_with"] == []
+
+
+def test_get_workflow_share_status_valid_until_not_set(
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
+):
+    workflow = sample_serial_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # Share the workflow without setting valid_until
+        client.post(
+            url_for(
+                "workflows.share_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
+            },
+        )
+        res = client.get(
+            url_for(
+                "workflows.get_workflow_share_status",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+            },
+        )
+        assert res.status_code == 200
+        response_data = res.get_json()
+        shared_with = response_data["shared_with"][0]
+        assert shared_with["valid_until"] is None
+
+
+def test_get_workflow_share_status_valid_until_set(
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
+):
+    workflow = sample_serial_workflow_in_db_owned_by_user1
+    valid_until = "2023-12-31"
+    with app.test_client() as client:
+        # Share the workflow setting valid_until
+        client.post(
+            url_for(
+                "workflows.share_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
+                "valid_until": valid_until,
+            },
+        )
+        res = client.get(
+            url_for(
+                "workflows.get_workflow_share_status",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+            },
+        )
+        assert res.status_code == 200
+        response_data = res.get_json()
+        shared_with = response_data["shared_with"][0]
+        assert shared_with["valid_until"] == valid_until + "T00:00:00"

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -32,7 +32,7 @@ status_dict = {
 }
 
 
-def test_get_workflows(app, session, default_user, cwl_workflow_with_name):
+def test_get_workflows(app, session, user0, cwl_workflow_with_name):
     """Test listing all workflows."""
     with app.test_client() as client:
         workflow_uuid = uuid.uuid4()
@@ -41,7 +41,7 @@ def test_get_workflows(app, session, default_user, cwl_workflow_with_name):
             id_=workflow_uuid,
             name=workflow_name,
             status=RunStatus.finished,
-            owner_id=default_user.id_,
+            owner_id=user0.id_,
             reana_specification=cwl_workflow_with_name["reana_specification"],
             type_=cwl_workflow_with_name["reana_specification"]["type"],
             logs="",
@@ -50,7 +50,7 @@ def test_get_workflows(app, session, default_user, cwl_workflow_with_name):
         session.commit()
         res = client.get(
             url_for("workflows.get_workflows"),
-            query_string={"user": default_user.id_, "type": "batch"},
+            query_string={"user": user0.id_, "type": "batch"},
         )
         assert res.status_code == 200
         response_data = json.loads(res.get_data(as_text=True))["items"]
@@ -90,25 +90,23 @@ def test_get_workflows_missing_user(app):
         assert res.status_code == 400
 
 
-def test_get_workflows_missing_type(app, default_user):
+def test_get_workflows_missing_type(app, user0):
     """Test listing all workflows with missing type."""
     with app.test_client() as client:
         res = client.get(
-            url_for("workflows.get_workflows"), query_string={"user": default_user.id_}
+            url_for("workflows.get_workflows"), query_string={"user": user0.id_}
         )
         assert res.status_code == 400
 
 
-def test_get_workflows_include_progress(
-    app, default_user, sample_yadage_workflow_in_db
-):
+def test_get_workflows_include_progress(app, user0, sample_yadage_workflow_in_db):
     """Test listing all workflows without including progress."""
     workflow = sample_yadage_workflow_in_db
     with app.test_client() as client:
         res = client.get(
             url_for("workflows.get_workflows"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "type": "batch",
                 "verbose": "true",
                 "include_progress": "false",
@@ -122,7 +120,7 @@ def test_get_workflows_include_progress(
 
 
 def test_get_workflows_include_retention_rules(
-    app, default_user, sample_yadage_workflow_in_db
+    app, user0, sample_yadage_workflow_in_db
 ):
     """Test listing all workflows without including retention rules."""
     workflow = sample_yadage_workflow_in_db
@@ -130,7 +128,7 @@ def test_get_workflows_include_retention_rules(
         res = client.get(
             url_for("workflows.get_workflows"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "type": "batch",
                 "verbose": "true",
                 "include_retention_rules": "false",
@@ -143,14 +141,14 @@ def test_get_workflows_include_retention_rules(
 
 
 def test_create_workflow_with_name(
-    app, session, default_user, cwl_workflow_with_name, tmp_shared_volume_path
+    app, session, user0, cwl_workflow_with_name, tmp_shared_volume_path
 ):
     """Test create workflow and its workspace by specifying a name."""
     with app.test_client() as client:
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -178,14 +176,14 @@ def test_create_workflow_with_name(
 
 
 def test_create_workflow_without_name(
-    app, session, default_user, cwl_workflow_without_name, tmp_shared_volume_path
+    app, session, user0, cwl_workflow_without_name, tmp_shared_volume_path
 ):
     """Test create workflow and its workspace without specifying a name."""
     with app.test_client() as client:
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -247,7 +245,7 @@ def test_create_workflow_wrong_user(
 
 
 def test_download_missing_file(
-    app, default_user, cwl_workflow_with_name, tmp_shared_volume_path
+    app, user0, cwl_workflow_with_name, tmp_shared_volume_path
 ):
     """Test download missing file."""
     with app.test_client() as client:
@@ -255,7 +253,7 @@ def test_download_missing_file(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -272,7 +270,7 @@ def test_download_missing_file(
                 workflow_id_or_name=workflow_uuid,
                 file_name=file_name,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -285,7 +283,7 @@ def test_download_missing_file(
 def test_download_file(
     app,
     session,
-    default_user,
+    user0,
     tmp_shared_volume_path,
     cwl_workflow_with_name,
     sample_serial_workflow_in_db,
@@ -296,7 +294,7 @@ def test_download_file(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -325,7 +323,7 @@ def test_download_file(
                 workflow_id_or_name=workflow_uuid,
                 file_name=file_name,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -333,7 +331,7 @@ def test_download_file(
 
 
 def test_download_file_with_path(
-    app, session, default_user, tmp_shared_volume_path, cwl_workflow_with_name
+    app, session, user0, tmp_shared_volume_path, cwl_workflow_with_name
 ):
     """Test download file prepended with path."""
     with app.test_client() as client:
@@ -341,7 +339,7 @@ def test_download_file_with_path(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -369,7 +367,7 @@ def test_download_file_with_path(
                 workflow_id_or_name=workflow_uuid,
                 file_name=file_name,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -377,7 +375,7 @@ def test_download_file_with_path(
 
 
 def test_download_dir_or_wildcard(
-    app, session, default_user, tmp_shared_volume_path, cwl_workflow_with_name
+    app, session, user0, tmp_shared_volume_path, cwl_workflow_with_name
 ):
     """Test download directory or file(s) matching a wildcard pattern."""
 
@@ -388,7 +386,7 @@ def test_download_dir_or_wildcard(
                 workflow_id_or_name=workflow_uuid,
                 file_name=pattern,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -398,7 +396,7 @@ def test_download_dir_or_wildcard(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -451,16 +449,14 @@ def test_download_dir_or_wildcard(
         assert res.data == files["foo/1.txt"]
 
 
-def test_get_files(
-    app, session, default_user, tmp_shared_volume_path, cwl_workflow_with_name
-):
+def test_get_files(app, session, user0, tmp_shared_volume_path, cwl_workflow_with_name):
     """Test get files list."""
     with app.test_client() as client:
         # create workflow
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -484,7 +480,7 @@ def test_get_files(
 
         res = client.get(
             url_for("workspaces.get_files", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -493,7 +489,7 @@ def test_get_files(
 
 
 def test_get_files_deleted_workflow(
-    app, default_user, tmp_shared_volume_path, cwl_workflow_with_name
+    app, user0, tmp_shared_volume_path, cwl_workflow_with_name
 ):
     """Test get files list of a deleted workflow without a workspace."""
     with app.test_client() as client:
@@ -501,7 +497,7 @@ def test_get_files_deleted_workflow(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -517,7 +513,7 @@ def test_get_files_deleted_workflow(
                 "statuses.set_workflow_status",
                 workflow_id_or_name=workflow_uuid,
             ),
-            query_string={"user": default_user.id_, "status": "deleted"},
+            query_string={"user": user0.id_, "status": "deleted"},
             content_type="application/json",
             data=json.dumps({}),
         )
@@ -530,20 +526,20 @@ def test_get_files_deleted_workflow(
         # get list of files
         res = client.get(
             url_for("workspaces.get_files", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
         assert res.status_code == 404
 
 
-def test_get_files_unknown_workflow(app, default_user):
+def test_get_files_unknown_workflow(app, user0):
     """Test get list of files for non existing workflow."""
     with app.test_client() as client:
         # create workflow
         random_workflow_uuid = str(uuid.uuid4())
         res = client.get(
             url_for("workspaces.get_files", workflow_id_or_name=random_workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
 
@@ -559,7 +555,7 @@ def test_get_files_unknown_workflow(app, default_user):
 
 
 def test_get_workflow_status_with_uuid(
-    app, session, default_user, cwl_workflow_with_name, tmp_shared_volume_path
+    app, session, user0, cwl_workflow_with_name, tmp_shared_volume_path
 ):
     """Test get workflow status."""
     with app.test_client() as client:
@@ -567,7 +563,7 @@ def test_get_workflow_status_with_uuid(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -580,7 +576,7 @@ def test_get_workflow_status_with_uuid(
 
         res = client.get(
             url_for("statuses.get_workflow_status", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -591,7 +587,7 @@ def test_get_workflow_status_with_uuid(
 
         res = client.get(
             url_for("statuses.get_workflow_status", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -599,9 +595,7 @@ def test_get_workflow_status_with_uuid(
         assert json_response.get("status") == workflow.status.name
 
 
-def test_get_workflow_status_with_name(
-    app, session, default_user, cwl_workflow_with_name
-):
+def test_get_workflow_status_with_name(app, session, user0, cwl_workflow_with_name):
     """Test get workflow status."""
     with app.test_client() as client:
         # create workflow
@@ -611,7 +605,7 @@ def test_get_workflow_status_with_name(
             id_=workflow_uuid,
             name=workflow_name,
             status=RunStatus.finished,
-            owner_id=default_user.id_,
+            owner_id=user0.id_,
             reana_specification=cwl_workflow_with_name["reana_specification"],
             type_=cwl_workflow_with_name["reana_specification"]["type"],
             logs="",
@@ -625,7 +619,7 @@ def test_get_workflow_status_with_name(
             url_for(
                 "statuses.get_workflow_status", workflow_id_or_name=workflow_name + ".1"
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -639,7 +633,7 @@ def test_get_workflow_status_with_name(
             url_for(
                 "statuses.get_workflow_status", workflow_id_or_name=workflow_name + ".1"
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -648,7 +642,7 @@ def test_get_workflow_status_with_name(
 
 
 def test_get_workflow_status_unauthorized(
-    app, default_user, cwl_workflow_with_name, tmp_shared_volume_path
+    app, user0, cwl_workflow_with_name, tmp_shared_volume_path
 ):
     """Test get workflow status unauthorized."""
     with app.test_client() as client:
@@ -656,7 +650,7 @@ def test_get_workflow_status_unauthorized(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -678,15 +672,13 @@ def test_get_workflow_status_unauthorized(
         assert res.status_code == 404
 
 
-def test_get_workflow_status_unknown_workflow(
-    app, default_user, cwl_workflow_with_name
-):
+def test_get_workflow_status_unknown_workflow(app, user0, cwl_workflow_with_name):
     """Test get workflow status for unknown workflow."""
     with app.test_client() as client:
         # create workflow
         res = client.post(
             url_for("workflows.create_workflow"),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -695,7 +687,7 @@ def test_get_workflow_status_unknown_workflow(
             url_for(
                 "statuses.get_workflow_status", workflow_id_or_name=random_workflow_uuid
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -707,7 +699,7 @@ def test_set_workflow_status(
     corev1_api_client_with_user_secrets,
     user_secrets,
     session,
-    default_user,
+    user0,
     yadage_workflow_with_name,
     tmp_shared_volume_path,
 ):
@@ -717,7 +709,7 @@ def test_set_workflow_status(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -744,7 +736,7 @@ def test_set_workflow_status(
                         "statuses.set_workflow_status",
                         workflow_id_or_name=workflow_created_uuid,
                     ),
-                    query_string={"user": default_user.id_, "status": "start"},
+                    query_string={"user": user0.id_, "status": "start"},
                 )
                 json_response = json.loads(res.data.decode())
                 assert json_response.get("status") == status_dict[payload].name
@@ -754,7 +746,7 @@ def test_set_workflow_status(
 def test_start_already_started_workflow(
     app,
     session,
-    default_user,
+    user0,
     corev1_api_client_with_user_secrets,
     user_secrets,
     yadage_workflow_with_name,
@@ -767,7 +759,7 @@ def test_start_already_started_workflow(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -794,7 +786,7 @@ def test_start_already_started_workflow(
                         "statuses.set_workflow_status",
                         workflow_id_or_name=workflow_created_uuid,
                     ),
-                    query_string={"user": default_user.id_, "status": "start"},
+                    query_string={"user": user0.id_, "status": "start"},
                 )
                 json_response = json.loads(res.data.decode())
                 assert json_response.get("status") == status_dict[payload].name
@@ -803,7 +795,7 @@ def test_start_already_started_workflow(
                         "statuses.set_workflow_status",
                         workflow_id_or_name=workflow_created_uuid,
                     ),
-                    query_string={"user": default_user.id_, "status": "start"},
+                    query_string={"user": user0.id_, "status": "start"},
                 )
                 json_response = json.loads(res.data.decode())
                 assert res.status_code == 409
@@ -830,7 +822,7 @@ def test_stop_workflow(
     expected_http_status_code,
     k8s_stop_call_count,
     app,
-    default_user,
+    user0,
     yadage_workflow_with_name,
     sample_serial_workflow_in_db,
     session,
@@ -849,7 +841,7 @@ def test_stop_workflow(
                     "statuses.set_workflow_status",
                     workflow_id_or_name=sample_serial_workflow_in_db.name,
                 ),
-                query_string={"user": default_user.id_, "status": "stop"},
+                query_string={"user": user0.id_, "status": "stop"},
             )
             assert sample_serial_workflow_in_db.status == expected_status
             assert res.status_code == expected_http_status_code
@@ -860,7 +852,7 @@ def test_stop_workflow(
 
 
 def test_set_workflow_status_unauthorized(
-    app, default_user, yadage_workflow_with_name, tmp_shared_volume_path
+    app, user0, yadage_workflow_with_name, tmp_shared_volume_path
 ):
     """Test set workflow status unauthorized."""
     with app.test_client() as client:
@@ -868,7 +860,7 @@ def test_set_workflow_status_unauthorized(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -891,7 +883,7 @@ def test_set_workflow_status_unauthorized(
 
 
 def test_set_workflow_status_unknown_workflow(
-    app, default_user, yadage_workflow_with_name, tmp_shared_volume_path
+    app, user0, yadage_workflow_with_name, tmp_shared_volume_path
 ):
     """Test set workflow status for unknown workflow."""
     with app.test_client() as client:
@@ -899,7 +891,7 @@ def test_set_workflow_status_unknown_workflow(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -911,7 +903,7 @@ def test_set_workflow_status_unknown_workflow(
             url_for(
                 "statuses.set_workflow_status", workflow_id_or_name=random_workflow_uuid
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(payload),
         )
@@ -919,7 +911,7 @@ def test_set_workflow_status_unknown_workflow(
 
 
 def test_upload_file(
-    app, session, default_user, tmp_shared_volume_path, cwl_workflow_with_name
+    app, session, user0, tmp_shared_volume_path, cwl_workflow_with_name
 ):
     """Test upload file."""
     with app.test_client() as client:
@@ -927,7 +919,7 @@ def test_upload_file(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -943,7 +935,7 @@ def test_upload_file(
 
         res = client.post(
             url_for("workspaces.upload_file", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_, "file_name": file_name},
+            query_string={"user": user0.id_, "file_name": file_name},
             content_type="application/octet-stream",
             input_stream=io.BytesIO(file_binary_content),
         )
@@ -962,7 +954,7 @@ def test_upload_file(
             assert f.read() == file_binary_content
 
 
-def test_upload_file_unknown_workflow(app, default_user):
+def test_upload_file_unknown_workflow(app, user0):
     """Test upload file to non existing workflow."""
     with app.test_client() as client:
         random_workflow_uuid = uuid.uuid4()
@@ -972,14 +964,14 @@ def test_upload_file_unknown_workflow(app, default_user):
 
         res = client.post(
             url_for("workspaces.upload_file", workflow_id_or_name=random_workflow_uuid),
-            query_string={"user": default_user.id_, "file_name": file_name},
+            query_string={"user": user0.id_, "file_name": file_name},
             content_type="application/octet-stream",
             input_stream=io.BytesIO(file_binary_content),
         )
         assert res.status_code == 404
 
 
-def test_delete_file(app, default_user, sample_serial_workflow_in_db):
+def test_delete_file(app, user0, sample_serial_workflow_in_db):
     """Test delete file."""
     # Move to fixture
     from flask import current_app
@@ -1000,14 +992,14 @@ def test_delete_file(app, default_user, sample_serial_workflow_in_db):
                 workflow_id_or_name=sample_serial_workflow_in_db.id_,
                 file_name=file_name,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
         )
         assert res.status_code == 200
         assert not os.path.exists(abs_path_to_file)
 
 
 def test_get_created_workflow_logs(
-    app, default_user, cwl_workflow_with_name, tmp_shared_volume_path
+    app, user0, cwl_workflow_with_name, tmp_shared_volume_path
 ):
     """Test get workflow logs."""
     with app.test_client() as client:
@@ -1015,7 +1007,7 @@ def test_get_created_workflow_logs(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -1026,7 +1018,7 @@ def test_get_created_workflow_logs(
         workflow_name = response_data.get("workflow_name")
         res = client.get(
             url_for("statuses.get_workflow_logs", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(None),
         )
@@ -1035,14 +1027,14 @@ def test_get_created_workflow_logs(
         expected_data = {
             "workflow_id": workflow_uuid,
             "workflow_name": workflow_name,
-            "user": str(default_user.id_),
+            "user": str(user0.id_),
             "logs": '{"workflow_logs": "", "job_logs": {},' ' "engine_specific": null}',
         }
         assert response_data == expected_data
 
 
 def test_get_unknown_workflow_logs(
-    app, default_user, yadage_workflow_with_name, tmp_shared_volume_path
+    app, user0, yadage_workflow_with_name, tmp_shared_volume_path
 ):
     """Test set workflow status for unknown workflow."""
     with app.test_client() as client:
@@ -1050,7 +1042,7 @@ def test_get_unknown_workflow_logs(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -1061,14 +1053,14 @@ def test_get_unknown_workflow_logs(
             url_for(
                 "statuses.get_workflow_logs", workflow_id_or_name=random_workflow_uuid
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
         assert res.status_code == 404
 
 
 def test_get_workflow_logs_unauthorized(
-    app, default_user, yadage_workflow_with_name, tmp_shared_volume_path
+    app, user0, yadage_workflow_with_name, tmp_shared_volume_path
 ):
     """Test set workflow status for unknown workflow."""
     with app.test_client() as client:
@@ -1076,7 +1068,7 @@ def test_get_workflow_logs_unauthorized(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -1096,7 +1088,7 @@ def test_get_workflow_logs_unauthorized(
 def test_start_input_parameters(
     app,
     session,
-    default_user,
+    user0,
     user_secrets,
     corev1_api_client_with_user_secrets,
     sample_serial_workflow_in_db,
@@ -1127,7 +1119,7 @@ def test_start_input_parameters(
                         "statuses.set_workflow_status",
                         workflow_id_or_name=workflow_created_uuid,
                     ),
-                    query_string={"user": default_user.id_, "status": "start"},
+                    query_string={"user": user0.id_, "status": "start"},
                     content_type="application/json",
                     data=json.dumps(parameters),
                 )
@@ -1142,7 +1134,7 @@ def test_start_input_parameters(
 def test_start_workflow_db_failure(
     app,
     session,
-    default_user,
+    user0,
     user_secrets,
     corev1_api_client_with_user_secrets,
     sample_serial_workflow_in_db,
@@ -1170,7 +1162,7 @@ def test_start_workflow_db_failure(
                     "statuses.set_workflow_status",
                     workflow_id_or_name=sample_serial_workflow_in_db.id_,
                 ),
-                query_string={"user": default_user.id_, "status": "start"},
+                query_string={"user": user0.id_, "status": "start"},
                 content_type="application/json",
                 data=json.dumps({}),
             )
@@ -1180,7 +1172,7 @@ def test_start_workflow_db_failure(
 def test_start_workflow_kubernetes_failure(
     app,
     session,
-    default_user,
+    user0,
     user_secrets,
     corev1_api_client_with_user_secrets,
     sample_serial_workflow_in_db,
@@ -1204,7 +1196,7 @@ def test_start_workflow_kubernetes_failure(
                     "statuses.set_workflow_status",
                     workflow_id_or_name=sample_serial_workflow_in_db.id_,
                 ),
-                query_string={"user": default_user.id_, "status": "start"},
+                query_string={"user": user0.id_, "status": "start"},
                 content_type="application/json",
                 data=json.dumps({}),
             )
@@ -1221,9 +1213,7 @@ def test_start_workflow_kubernetes_failure(
         pytest.param(RunStatus.running, marks=pytest.mark.xfail(strict=True)),
     ],
 )
-def test_delete_workflow(
-    app, session, default_user, sample_yadage_workflow_in_db, status
-):
+def test_delete_workflow(app, session, user0, sample_yadage_workflow_in_db, status):
     """Test deletion of a workflow in all possible statuses."""
     sample_yadage_workflow_in_db.status = status
     session.add(sample_yadage_workflow_in_db)
@@ -1234,23 +1224,21 @@ def test_delete_workflow(
                 "statuses.set_workflow_status",
                 workflow_id_or_name=sample_yadage_workflow_in_db.id_,
             ),
-            query_string={"user": default_user.id_, "status": "deleted"},
+            query_string={"user": user0.id_, "status": "deleted"},
             content_type="application/json",
             data=json.dumps({}),
         )
         assert sample_yadage_workflow_in_db.status == RunStatus.deleted
 
 
-def test_delete_all_workflow_runs(
-    app, session, default_user, yadage_workflow_with_name
-):
+def test_delete_all_workflow_runs(app, session, user0, yadage_workflow_with_name):
     """Test deletion of all runs of a given workflow."""
     # add 5 workflows in the database with the same name
     for i in range(5):
         workflow = Workflow(
             id_=uuid.uuid4(),
             name=yadage_workflow_with_name["name"],
-            owner_id=default_user.id_,
+            owner_id=user0.id_,
             reana_specification=yadage_workflow_with_name["reana_specification"],
             operational_options={},
             type_=yadage_workflow_with_name["reana_specification"]["workflow"]["type"],
@@ -1269,7 +1257,7 @@ def test_delete_all_workflow_runs(
             url_for(
                 "statuses.set_workflow_status", workflow_id_or_name=first_workflow.id_
             ),
-            query_string={"user": default_user.id_, "status": "deleted"},
+            query_string={"user": user0.id_, "status": "deleted"},
             content_type="application/json",
             data=json.dumps({"all_runs": True}),
         )
@@ -1283,7 +1271,7 @@ def test_delete_all_workflow_runs(
 def test_workspace_deletion(
     app,
     session,
-    default_user,
+    user0,
     yadage_workflow_with_name,
     tmp_shared_volume_path,
     workspace,
@@ -1293,7 +1281,7 @@ def test_workspace_deletion(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -1322,7 +1310,7 @@ def test_workspace_deletion(
                 url_for(
                     "statuses.set_workflow_status", workflow_id_or_name=workflow.id_
                 ),
-                query_string={"user": default_user.id_, "status": "deleted"},
+                query_string={"user": user0.id_, "status": "deleted"},
                 content_type="application/json",
                 data=json.dumps({"workspace": workspace}),
             )
@@ -1339,14 +1327,14 @@ def test_workspace_deletion(
 
 
 def test_deletion_of_workspace_of_an_already_deleted_workflow(
-    app, session, default_user, yadage_workflow_with_name, tmp_shared_volume_path
+    app, session, user0, yadage_workflow_with_name, tmp_shared_volume_path
 ):
     """Test workspace deletion of an already deleted workflow."""
     with app.test_client() as client:
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -1367,7 +1355,7 @@ def test_deletion_of_workspace_of_an_already_deleted_workflow(
                 url_for(
                     "statuses.set_workflow_status", workflow_id_or_name=workflow.id_
                 ),
-                query_string={"user": default_user.id_, "status": "deleted"},
+                query_string={"user": user0.id_, "status": "deleted"},
                 content_type="application/json",
                 data=json.dumps({"workspace": False}),
             )
@@ -1379,7 +1367,7 @@ def test_deletion_of_workspace_of_an_already_deleted_workflow(
 
 def test_get_workflow_diff(
     app,
-    default_user,
+    user0,
     sample_yadage_workflow_in_db,
     sample_serial_workflow_in_db,
     tmp_shared_volume_path,
@@ -1392,7 +1380,7 @@ def test_get_workflow_diff(
                 workflow_id_or_name_a=sample_serial_workflow_in_db.id_,
                 workflow_id_or_name_b=sample_yadage_workflow_in_db.id_,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
         assert res.status_code == 200
@@ -1429,7 +1417,7 @@ def test_get_workflow_diff(
 
 def test_get_workspace_diff(
     app,
-    default_user,
+    user0,
     sample_yadage_workflow_in_db,
     sample_serial_workflow_in_db,
     tmp_shared_volume_path,
@@ -1457,7 +1445,7 @@ def test_get_workspace_diff(
                 workflow_id_or_name_a=sample_serial_workflow_in_db.id_,
                 workflow_id_or_name_b=sample_yadage_workflow_in_db.id_,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
         assert res.status_code == 200
@@ -1465,7 +1453,7 @@ def test_get_workspace_diff(
         assert "# File" in response_data["workspace_listing"]
 
 
-def test_create_interactive_session(app, default_user, sample_serial_workflow_in_db):
+def test_create_interactive_session(app, user0, sample_serial_workflow_in_db):
     """Test create interactive session."""
     wrm = WorkflowRunManager(sample_serial_workflow_in_db)
     expected_data = {"path": wrm._generate_interactive_workflow_path()}
@@ -1483,13 +1471,13 @@ def test_create_interactive_session(app, default_user, sample_serial_workflow_in
                     workflow_id_or_name=sample_serial_workflow_in_db.id_,
                     interactive_session_type="jupyter",
                 ),
-                query_string={"user": default_user.id_},
+                query_string={"user": user0.id_},
             )
             assert res.json == expected_data
 
 
 def test_create_interactive_session_unknown_type(
-    app, default_user, sample_serial_workflow_in_db
+    app, user0, sample_serial_workflow_in_db
 ):
     """Test create interactive session for unknown interactive type."""
     with app.test_client() as client:
@@ -1500,13 +1488,13 @@ def test_create_interactive_session_unknown_type(
                 workflow_id_or_name=sample_serial_workflow_in_db.id_,
                 interactive_session_type="terminl",
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
         )
         assert res.status_code == 404
 
 
 def test_create_interactive_session_custom_image(
-    app, default_user, sample_serial_workflow_in_db
+    app, user0, sample_serial_workflow_in_db
 ):
     """Create an interactive session with custom image."""
     custom_image = "test/image"
@@ -1525,7 +1513,7 @@ def test_create_interactive_session_custom_image(
                     workflow_id_or_name=sample_serial_workflow_in_db.id_,
                     interactive_session_type="jupyter",
                 ),
-                query_string={"user": default_user.id_},
+                query_string={"user": user0.id_},
                 content_type="application/json",
                 data=json.dumps(interactive_session_configuration),
             )
@@ -1535,9 +1523,7 @@ def test_create_interactive_session_custom_image(
             assert fargs[1].spec.template.spec.containers[0].image == custom_image
 
 
-def test_close_interactive_session(
-    app, session, default_user, sample_serial_workflow_in_db
-):
+def test_close_interactive_session(app, session, user0, sample_serial_workflow_in_db):
     """Test close an interactive session."""
     expected_data = {"message": "The interactive session has been closed"}
     path = "/5d9b30fd-f225-4615-9107-b1373afec070"
@@ -1559,14 +1545,14 @@ def test_close_interactive_session(
                     "workflows_session.close_interactive_session",
                     workflow_id_or_name=sample_serial_workflow_in_db.id_,
                 ),
-                query_string={"user": default_user.id_},
+                query_string={"user": user0.id_},
                 content_type="application/json",
             )
         assert res.json == expected_data
 
 
 def test_close_interactive_session_not_opened(
-    app, session, default_user, sample_serial_workflow_in_db
+    app, session, user0, sample_serial_workflow_in_db
 ):
     """Test close an interactive session when session is not opened."""
     expected_data = {
@@ -1583,7 +1569,7 @@ def test_close_interactive_session_not_opened(
                 "workflows_session.close_interactive_session",
                 workflow_id_or_name=sample_serial_workflow_in_db.id_,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
         assert res.json == expected_data
@@ -1626,7 +1612,7 @@ def test_get_workflow_retention_rules_no_rules(app, sample_serial_workflow_in_db
         assert res.json["retention_rules"] == []
 
 
-def test_get_workflow_retention_rules_invalid_workflow(app, default_user):
+def test_get_workflow_retention_rules_invalid_workflow(app, user0):
     """Test get_workflow_retention_rules for invalid workflow."""
     with app.test_client() as client:
         res = client.get(
@@ -1634,7 +1620,7 @@ def test_get_workflow_retention_rules_invalid_workflow(app, default_user):
                 "workflows.get_workflow_retention_rules",
                 workflow_id_or_name="invalid_name",
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
         )
         assert res.status_code == 404
         assert b"invalid_name" in res.data
@@ -1654,9 +1640,9 @@ def test_get_workflow_retention_rules_invalid_user(app, sample_serial_workflow_i
         assert res.status_code == 404
 
 
-def test_share_workflow(app, default_user, second_user, sample_serial_workflow_in_db):
+def test_share_workflow(app, user1, user2, sample_serial_workflow_in_db_owned_by_user1):
     """Test share workflow."""
-    workflow = sample_serial_workflow_in_db
+    workflow = sample_serial_workflow_in_db_owned_by_user1
     with app.test_client() as client:
         res = client.post(
             url_for(
@@ -1664,8 +1650,8 @@ def test_share_workflow(app, default_user, second_user, sample_serial_workflow_i
                 workflow_id_or_name=str(workflow.id_),
             ),
             query_string={
-                "user_id": str(default_user.id_),
-                "user_email_to_share_with": second_user.email,
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
             },
         )
         assert res.status_code == 200
@@ -1674,10 +1660,10 @@ def test_share_workflow(app, default_user, second_user, sample_serial_workflow_i
 
 
 def test_share_workflow_with_message_and_valid_until(
-    app, default_user, second_user, sample_serial_workflow_in_db
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
 ):
     """Test share workflow with a message and a valid until date."""
-    workflow = sample_serial_workflow_in_db
+    workflow = sample_serial_workflow_in_db_owned_by_user1
     message = "This is a shared workflow with a message."
     valid_until = "2023-12-31"
     with app.test_client() as client:
@@ -1687,8 +1673,8 @@ def test_share_workflow_with_message_and_valid_until(
                 workflow_id_or_name=str(workflow.id_),
             ),
             query_string={
-                "user_id": str(default_user.id_),
-                "user_email_to_share_with": second_user.email,
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
                 "message": message,
                 "valid_until": valid_until,
             },
@@ -1698,9 +1684,11 @@ def test_share_workflow_with_message_and_valid_until(
         assert response_data["message"] == "The workflow has been shared with the user."
 
 
-def test_share_workflow_invalid_email(app, second_user, sample_serial_workflow_in_db):
+def test_share_workflow_invalid_email(
+    app, user2, sample_serial_workflow_in_db_owned_by_user1
+):
     """Test share workflow with invalid email format."""
-    workflow = sample_serial_workflow_in_db
+    workflow = sample_serial_workflow_in_db_owned_by_user1
     invalid_emails = [
         "invalid_email",
         "invalid_email@",
@@ -1722,7 +1710,7 @@ def test_share_workflow_invalid_email(app, second_user, sample_serial_workflow_i
                     workflow_id_or_name=str(workflow.id_),
                 ),
                 query_string={
-                    "user_id": str(second_user.id_),
+                    "user_id": str(user2.id_),
                     "user_email_to_share_with": invalid_email,
                 },
             )
@@ -1735,16 +1723,16 @@ def test_share_workflow_invalid_email(app, second_user, sample_serial_workflow_i
 
 
 def test_share_workflow_with_valid_email_but_unexisting_user(
-    app, default_user, second_user, sample_serial_workflow_in_db
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
 ):
     """Test share workflow with valid email but unexisting user."""
-    workflow = sample_serial_workflow_in_db
+    workflow = sample_serial_workflow_in_db_owned_by_user1
     valid_emails = [
         "valid_email@example.com",
         "another_valid_email@test.org",
         "john.doe@email-domain.net",
         "alice.smith@sub.domain.co.uk",
-        "user1234@gmail.com",
+        "user2234@gmail.com",
         "admin@company.com",
         "support@website.org",
         "marketing@example.net",
@@ -1760,7 +1748,7 @@ def test_share_workflow_with_valid_email_but_unexisting_user(
                     workflow_id_or_name=str(workflow.id_),
                 ),
                 query_string={
-                    "user_id": str(default_user.id_),
+                    "user_id": str(user1.id_),
                     "user_email_to_share_with": valid_email,
                 },
             )
@@ -1773,10 +1761,10 @@ def test_share_workflow_with_valid_email_but_unexisting_user(
 
 
 def test_share_workflow_with_invalid_date_format(
-    app, default_user, second_user, sample_serial_workflow_in_db
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
 ):
     """Test share workflow with an invalid date format for 'valid_until'."""
-    workflow = sample_serial_workflow_in_db
+    workflow = sample_serial_workflow_in_db_owned_by_user1
     invalid_date = "2023/12/31"  # Invalid format
     with app.test_client() as client:
         res = client.post(
@@ -1785,8 +1773,8 @@ def test_share_workflow_with_invalid_date_format(
                 workflow_id_or_name=str(workflow.id_),
             ),
             query_string={
-                "user_id": str(default_user.id_),
-                "user_email_to_share_with": second_user.email,
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
                 "valid_until": invalid_date,
             },
         )
@@ -1798,7 +1786,7 @@ def test_share_workflow_with_invalid_date_format(
         )
 
 
-def test_share_non_existent_workflow(app, default_user, second_user):
+def test_share_non_existent_workflow(app, user1, user2):
     """Test sharing a non-existent workflow."""
     non_existent_workflow_id = "non_existent_workflow_id"
     with app.test_client() as client:
@@ -1808,21 +1796,23 @@ def test_share_non_existent_workflow(app, default_user, second_user):
                 workflow_id_or_name=non_existent_workflow_id,
             ),
             query_string={
-                "user_id": str(default_user.id_),
-                "user_email_to_share_with": second_user.email,
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
             },
         )
-        assert res.status_code == 404
+        assert res.status_code == 400
         response_data = res.get_json()
         assert (
             response_data["message"]
-            == f"Workflow {non_existent_workflow_id} does not exist."
+            == f"REANA_WORKON is set to {non_existent_workflow_id}, but that workflow does not exist. Please set your REANA_WORKON environment variable appropriately."
         )
 
 
-def test_share_workflow_with_self(app, default_user, sample_serial_workflow_in_db):
+def test_share_workflow_with_self(
+    app, user1, sample_serial_workflow_in_db_owned_by_user1
+):
     """Test attempting to share a workflow with yourself."""
-    workflow = sample_serial_workflow_in_db
+    workflow = sample_serial_workflow_in_db_owned_by_user1
     with app.test_client() as client:
         res = client.post(
             url_for(
@@ -1830,8 +1820,8 @@ def test_share_workflow_with_self(app, default_user, sample_serial_workflow_in_d
                 workflow_id_or_name=str(workflow.id_),
             ),
             query_string={
-                "user_id": str(default_user.id_),
-                "user_email_to_share_with": default_user.email,
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user1.email,
             },
         )
         assert res.status_code == 400
@@ -1840,10 +1830,10 @@ def test_share_workflow_with_self(app, default_user, sample_serial_workflow_in_d
 
 
 def test_share_workflow_already_shared(
-    app, default_user, second_user, sample_serial_workflow_in_db
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
 ):
     """Test attempting to share a workflow that is already shared with the user."""
-    workflow = sample_serial_workflow_in_db
+    workflow = sample_serial_workflow_in_db_owned_by_user1
     with app.test_client() as client:
         client.post(
             url_for(
@@ -1851,8 +1841,8 @@ def test_share_workflow_already_shared(
                 workflow_id_or_name=str(workflow.id_),
             ),
             query_string={
-                "user_id": str(default_user.id_),
-                "user_email_to_share_with": second_user.email,
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
             },
         )
 
@@ -1864,23 +1854,23 @@ def test_share_workflow_already_shared(
                 workflow_id_or_name=str(workflow.id_),
             ),
             query_string={
-                "user_id": str(default_user.id_),
-                "user_email_to_share_with": second_user.email,
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
             },
         )
         assert res.status_code == 409
         response_data = res.get_json()
         assert (
             response_data["message"]
-            == f"{workflow.get_full_workflow_name()} is already shared with {second_user.email}."
+            == f"{workflow.get_full_workflow_name()} is already shared with {user2.email}."
         )
 
 
 def test_share_workflow_with_past_valid_until_date(
-    app, default_user, second_user, sample_serial_workflow_in_db
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
 ):
     """Test share workflow with a 'valid_until' date in the past."""
-    workflow = sample_serial_workflow_in_db
+    workflow = sample_serial_workflow_in_db_owned_by_user1
     past_date = "2021-01-01"  # A date in the past
     with app.test_client() as client:
         res = client.post(
@@ -1889,8 +1879,8 @@ def test_share_workflow_with_past_valid_until_date(
                 workflow_id_or_name=str(workflow.id_),
             ),
             query_string={
-                "user_id": str(default_user.id_),
-                "user_email_to_share_with": second_user.email,
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
                 "valid_until": past_date,
             },
         )
@@ -1902,10 +1892,10 @@ def test_share_workflow_with_past_valid_until_date(
 
 
 def test_share_workflow_with_long_message(
-    app, default_user, second_user, sample_serial_workflow_in_db
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
 ):
     """Test share workflow with a message exceeding 5000 characters."""
-    workflow = sample_serial_workflow_in_db
+    workflow = sample_serial_workflow_in_db_owned_by_user1
     long_message = "A" * 5001  # A message exceeding the 5000-character limit
     with app.test_client() as client:
         res = client.post(
@@ -1914,8 +1904,8 @@ def test_share_workflow_with_long_message(
                 workflow_id_or_name=str(workflow.id_),
             ),
             query_string={
-                "user_id": str(default_user.id_),
-                "user_email_to_share_with": second_user.email,
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
                 "message": long_message,
             },
         )
@@ -1929,13 +1919,13 @@ def test_share_workflow_with_long_message(
 
 def test_share_multiple_workflows(
     app,
-    default_user,
-    second_user,
-    sample_serial_workflow_in_db,
-    sample_yadage_workflow_in_db,
+    user1,
+    user2,
+    sample_serial_workflow_in_db_owned_by_user1,
+    sample_yadage_workflow_in_db_owned_by_user1,
 ):
     """Test sharing multiple workflows with different users."""
-    workflow1 = sample_serial_workflow_in_db
+    workflow1 = sample_serial_workflow_in_db_owned_by_user1
     with app.test_client() as client:
         res = client.post(
             url_for(
@@ -1943,15 +1933,15 @@ def test_share_multiple_workflows(
                 workflow_id_or_name=str(workflow1.id_),
             ),
             query_string={
-                "user_id": str(default_user.id_),
-                "user_email_to_share_with": second_user.email,
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
             },
         )
         assert res.status_code == 200
         response_data = res.get_json()
         assert response_data["message"] == "The workflow has been shared with the user."
 
-    workflow2 = sample_yadage_workflow_in_db
+    workflow2 = sample_yadage_workflow_in_db_owned_by_user1
     with app.test_client() as client:
         res = client.post(
             url_for(
@@ -1959,8 +1949,8 @@ def test_share_multiple_workflows(
                 workflow_id_or_name=str(workflow2.id_),
             ),
             query_string={
-                "user_id": str(default_user.id_),
-                "user_email_to_share_with": second_user.email,
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
             },
         )
         assert res.status_code == 200

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1956,3 +1956,315 @@ def test_share_multiple_workflows(
         assert res.status_code == 200
         response_data = res.get_json()
         assert response_data["message"] == "The workflow has been shared with the user."
+
+
+def test_unshare_workflow(
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
+):
+    """Test unshare workflow."""
+    workflow = sample_serial_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # share workflow
+        client.post(
+            url_for(
+                "workflows.share_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
+            },
+        )
+        # unshare workflow
+        res = client.post(
+            url_for(
+                "workflows.unshare_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_unshare_with": user2.email,
+            },
+        )
+        assert res.status_code == 200
+        response_data = res.get_json()
+        assert (
+            response_data["message"] == "The workflow has been unshared with the user."
+        )
+
+
+def test_unshare_workflow_not_shared(
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
+):
+    """Test unshare workflow that is not shared with the user."""
+    workflow = sample_serial_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # unshare workflow
+        res = client.post(
+            url_for(
+                "workflows.unshare_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_unshare_with": user2.email,
+            },
+        )
+        assert res.status_code == 409
+        response_data = res.get_json()
+        assert (
+            response_data["message"]
+            == f"{workflow.get_full_workflow_name()} is not shared with {user2.email}."
+        )
+
+
+def test_unshare_workflow_with_self(
+    app, user1, sample_serial_workflow_in_db_owned_by_user1
+):
+    """Test attempting to unshare a workflow with yourself."""
+    workflow = sample_serial_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        res = client.post(
+            url_for(
+                "workflows.unshare_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_unshare_with": user1.email,
+            },
+        )
+        assert res.status_code == 400
+        response_data = res.get_json()
+        assert response_data["message"] == "Unable to unshare a workflow with yourself."
+
+
+def test_unshare_workflow_with_invalid_email(
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
+):
+    """Test unshare workflow with invalid email format."""
+    workflow = sample_serial_workflow_in_db_owned_by_user1
+    invalid_emails = [
+        "invalid_email",
+        "invalid_email@",
+        "@invalid_email.com",
+        "invalid_email.com",
+        "invalid@ email.com",  # Contains a space
+        "invalid @email",  # Contains a space
+        "invalid_email@.com",  # Empty domain
+        "invalid_email@com.",  # Empty top-level domain
+        "invalid_email@com",  # Missing top-level domain
+        "invalid_email@com.",  # Extra dot in top-level domain
+    ]
+
+    with app.test_client() as client:
+        for invalid_email in invalid_emails:
+            res = client.post(
+                url_for(
+                    "workflows.unshare_workflow",
+                    workflow_id_or_name=str(workflow.id_),
+                ),
+                query_string={
+                    "user_id": str(user1.id_),
+                    "user_email_to_unshare_with": invalid_email,
+                },
+            )
+            assert res.status_code == 400
+            response_data = res.get_json()
+            assert (
+                response_data["message"]
+                == f"User email '{invalid_email}' is not valid."
+            )
+
+
+def test_unshare_workflow_with_valid_email_but_unexisting_user(
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
+):
+    """Test unshare workflow with valid email but unexisting user."""
+    workflow = sample_serial_workflow_in_db_owned_by_user1
+    valid_emails = [
+        "valid_email@example.com",
+        "another_valid_email@test.org",
+        "john.doe@email-domain.net",
+        "alice.smith@sub.domain.co.uk",
+        "user2234@gmail.com",
+        "admin@company.com",
+        "support@website.org",
+        "marketing@example.net",
+        "jane_doe@sub.example.co",
+        "user.name@sub.domain.co.uk",
+    ]
+
+    with app.test_client() as client:
+        for valid_email in valid_emails:
+            res = client.post(
+                url_for(
+                    "workflows.unshare_workflow",
+                    workflow_id_or_name=str(workflow.id_),
+                ),
+                query_string={
+                    "user_id": str(user1.id_),
+                    "user_email_to_unshare_with": valid_email,
+                },
+            )
+            assert res.status_code == 404
+            response_data = res.get_json()
+            assert (
+                response_data["message"]
+                == f"User with email '{valid_email}' does not exist."
+            )
+
+
+def test_unshare_non_existent_workflow(app, user1, user2):
+    """Test unsharing a non-existent workflow."""
+    non_existent_workflow_id = "non_existent_workflow_id"
+    with app.test_client() as client:
+        res = client.post(
+            url_for(
+                "workflows.unshare_workflow",
+                workflow_id_or_name=non_existent_workflow_id,
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_unshare_with": user2.email,
+            },
+        )
+        assert res.status_code == 400
+        response_data = res.get_json()
+        assert (
+            response_data["message"]
+            == f"REANA_WORKON is set to {non_existent_workflow_id}, but that workflow does not exist. Please set your REANA_WORKON environment variable appropriately."
+        )
+
+
+def test_unshare_workflow_already_unshared(
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
+):
+    """Test unsharing a workflow that is already unshared with the user."""
+    workflow = sample_serial_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # unshare workflow
+        res = client.post(
+            url_for(
+                "workflows.unshare_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_unshare_with": user2.email,
+            },
+        )
+        assert res.status_code == 409
+        response_data = res.get_json()
+        assert (
+            response_data["message"]
+            == f"{workflow.get_full_workflow_name()} is not shared with {user2.email}."
+        )
+
+
+def test_unshare_multiple_workflows(
+    app,
+    user1,
+    user2,
+    sample_serial_workflow_in_db_owned_by_user1,
+    sample_yadage_workflow_in_db_owned_by_user1,
+):
+    """Test unsharing multiple workflows with different users."""
+    workflow1 = sample_serial_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # share workflow
+        client.post(
+            url_for(
+                "workflows.share_workflow",
+                workflow_id_or_name=str(workflow1.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
+            },
+        )
+        # unshare workflow
+        res = client.post(
+            url_for(
+                "workflows.unshare_workflow",
+                workflow_id_or_name=str(workflow1.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_unshare_with": user2.email,
+            },
+        )
+        assert res.status_code == 200
+        response_data = res.get_json()
+        assert (
+            response_data["message"] == "The workflow has been unshared with the user."
+        )
+
+    workflow2 = sample_yadage_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # share workflow
+        client.post(
+            url_for(
+                "workflows.share_workflow",
+                workflow_id_or_name=str(workflow2.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
+            },
+        )
+        # unshare workflow
+        res = client.post(
+            url_for(
+                "workflows.unshare_workflow",
+                workflow_id_or_name=str(workflow2.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_unshare_with": user2.email,
+            },
+        )
+        assert res.status_code == 200
+        response_data = res.get_json()
+        assert (
+            response_data["message"] == "The workflow has been unshared with the user."
+        )
+
+
+def test_unshare_workflow_with_message_and_valid_until(
+    app, user1, user2, sample_serial_workflow_in_db_owned_by_user1
+):
+    """Test unshare workflow with a message and a valid until date."""
+    workflow = sample_serial_workflow_in_db_owned_by_user1
+    message = "This is a shared workflow with a message."
+    valid_until = "2023-12-31"
+    with app.test_client() as client:
+        # share workflow
+        client.post(
+            url_for(
+                "workflows.share_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
+                "message": message,
+                "valid_until": valid_until,
+            },
+        )
+        # unshare workflow
+        res = client.post(
+            url_for(
+                "workflows.unshare_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_unshare_with": user2.email,
+            },
+        )
+        assert res.status_code == 200
+        response_data = res.get_json()
+        assert (
+            response_data["message"] == "The workflow has been unshared with the user."
+        )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -64,6 +64,8 @@ def test_get_workflows(app, session, user0, cwl_workflow_with_name):
                 "progress": response_data[0]["progress"],
                 "size": {"raw": -1, "human_readable": ""},
                 "launcher_url": None,
+                "owner_email": "-",
+                "shared_with": "-",
             }
         ]
 
@@ -138,6 +140,140 @@ def test_get_workflows_include_retention_rules(
         response_data = json.loads(res.get_data(as_text=True))["items"][0]
         assert response_data["id"] == str(workflow.id_)
         assert "retention_rules" not in response_data
+
+
+def test_get_workflows_shared(
+    app, user1, user2, sample_yadage_workflow_in_db_owned_by_user1
+):
+    """Test listing shared workflows."""
+    workflow = sample_yadage_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # share workflow with user2
+        res = client.post(
+            url_for(
+                "workflows.share_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
+            },
+        )
+
+        # list shared workflows for user2
+        res = client.get(
+            url_for("workflows.get_workflows"),
+            query_string={"user": user1.id_, "shared": True, "type": "batch"},
+        )
+        assert res.status_code == 200
+        response_data = json.loads(res.get_data(as_text=True))["items"]
+        assert len(response_data) == 1
+        assert response_data[0]["id"] == str(workflow.id_)
+        assert response_data[0]["shared_with"] == user2.email
+        assert response_data[0]["owner_email"] == "-"
+
+
+def test_get_workflows_shared_by(
+    app, user1, user2, sample_yadage_workflow_in_db_owned_by_user1
+):
+    """Test listing workflows shared by a user."""
+    workflow = sample_yadage_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # share workflow with user2
+        res = client.post(
+            url_for(
+                "workflows.share_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
+            },
+        )
+
+        # list shared workflows for user1
+        res = client.get(
+            url_for("workflows.get_workflows"),
+            query_string={
+                "user": user2.id_,
+                "shared_by": user1.email,
+                "type": "batch",
+            },
+        )
+        assert res.status_code == 200
+        response_data = json.loads(res.get_data(as_text=True))["items"]
+        assert len(response_data) == 1
+        assert response_data[0]["id"] == str(workflow.id_)
+        assert response_data[0]["owner_email"] == user1.email
+
+
+def test_get_workflows_shared_with(
+    app, user1, user2, sample_yadage_workflow_in_db_owned_by_user1
+):
+    """Test listing workflows shared with a user."""
+    workflow = sample_yadage_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # share workflow with user2
+        res = client.post(
+            url_for(
+                "workflows.share_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
+            },
+        )
+
+        # list shared workflows for user2
+        res = client.get(
+            url_for("workflows.get_workflows"),
+            query_string={
+                "user": user1.id_,
+                "shared_with": user2.email,
+                "type": "batch",
+            },
+        )
+        assert res.status_code == 200
+        response_data = json.loads(res.get_data(as_text=True))["items"]
+        assert len(response_data) == 1
+        assert response_data[0]["id"] == str(workflow.id_)
+        assert response_data[0]["shared_with"] == user2.email
+
+
+def test_get_workflows_shared_by_and_shared_with(
+    app, user1, user2, sample_yadage_workflow_in_db_owned_by_user1
+):
+    """Test listing workflows shared by and shared with a user."""
+    workflow = sample_yadage_workflow_in_db_owned_by_user1
+    with app.test_client() as client:
+        # share workflow with user2
+        res = client.post(
+            url_for(
+                "workflows.share_workflow",
+                workflow_id_or_name=str(workflow.id_),
+            ),
+            query_string={
+                "user_id": str(user1.id_),
+                "user_email_to_share_with": user2.email,
+            },
+        )
+
+        # list shared workflows for user2
+        res = client.get(
+            url_for("workflows.get_workflows"),
+            query_string={
+                "user": user2.id_,
+                "shared_with": user1.email,
+                "shared_by": user1.email,
+                "type": "batch",
+            },
+        )
+        assert res.status_code == 400
+        response_data = res.get_json()
+        assert response_data["message"] == (
+            "You cannot filter by shared_by and shared_with at the same time."
+        )
 
 
 def test_create_workflow_with_name(


### PR DESCRIPTION
Adds new `shared`, `shared_with` and `shared_by` parameters to the
`get_workflows` endpoint to retrieve workflows along with their sharing
information.

Closes reanahub/reana-client#687
