### PR TITLE
rest: make details available for shared workflows

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,6 +7,7 @@ The list of contributors in alphabetical order:
 - [Anton Khodak](https://orcid.org/0000-0003-3263-4553)
 - [Audrius Mecionis](https://orcid.org/0000-0002-3759-1663)
 - [Camila Diaz](https://orcid.org/0000-0001-5543-797X)
+- [Daan Rosendal](https://orcid.org/0000-0002-3447-9000)
 - [Diego Rodriguez](https://orcid.org/0000-0003-0649-2002)
 - [Dinos Kousidis](https://orcid.org/0000-0002-4914-4289)
 - [Giuseppe Steduto](https://orcid.org/0009-0002-1258-8553)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -89,6 +89,27 @@
             "name": "workflow_id_or_name",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "Optional flag to list all shared (owned and unowned) workflows.",
+            "in": "query",
+            "name": "shared",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "description": "Optional argument to list workflows shared by the specified user(s).",
+            "in": "query",
+            "name": "shared_by",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Optional argument to list workflows shared with the specified user(s).",
+            "in": "query",
+            "name": "shared_with",
+            "required": false,
+            "type": "string"
           }
         ],
         "produces": [
@@ -167,8 +188,14 @@
                       "name": {
                         "type": "string"
                       },
+                      "owner_email": {
+                        "type": "string"
+                      },
                       "progress": {
                         "type": "object"
+                      },
+                      "shared_with": {
+                        "type": "string"
                       },
                       "size": {
                         "properties": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1098,6 +1098,139 @@
         "summary": "Share a workflow with other users."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/share-status": {
+      "get": {
+        "description": "This resource returns the share status of a given workflow.",
+        "operationId": "get_workflow_share_status",
+        "parameters": [
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Workflow UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The response contains the share status of the workflow.",
+            "examples": {
+              "application/json": {
+                "shared_with": [
+                  {
+                    "user_email": "bob@example.org",
+                    "valid_until": "2022-11-24T23:59:59"
+                  }
+                ],
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "shared_with": {
+                  "items": {
+                    "properties": {
+                      "user_email": {
+                        "type": "string"
+                      },
+                      "valid_until": {
+                        "type": "string",
+                        "x-nullable": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Request failed. User not signed in.",
+            "examples": {
+              "application/json": {
+                "message": "User not signed in."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. Credentials are invalid or revoked.",
+            "examples": {
+              "application/json": {
+                "message": "Token not valid."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist.",
+            "examples": {
+              "application/json": {
+                "message": "Workflow mytest.1 does not exist."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal server error.",
+            "examples": {
+              "application/json": {
+                "message": "Something went wrong."
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Get the share status of a workflow."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/status": {
       "get": {
         "description": "This resource reports the status of workflow.",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -98,14 +98,14 @@
             "type": "boolean"
           },
           {
-            "description": "Optional argument to list workflows shared by the specified user(s).",
+            "description": "Optional argument to list workflows shared by the specified user.",
             "in": "query",
             "name": "shared_by",
             "required": false,
             "type": "string"
           },
           {
-            "description": "Optional argument to list workflows shared with the specified user(s).",
+            "description": "Optional argument to list workflows shared with the specified user.",
             "in": "query",
             "name": "shared_with",
             "required": false,
@@ -195,7 +195,10 @@
                         "type": "object"
                       },
                       "shared_with": {
-                        "type": "string"
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
                       },
                       "size": {
                         "properties": {
@@ -1133,7 +1136,7 @@
           {
             "description": "Required. UUID of workflow owner.",
             "in": "query",
-            "name": "user_id",
+            "name": "user",
             "required": true,
             "type": "string"
           },
@@ -1184,38 +1187,6 @@
                   "type": "string"
                 },
                 "workflow_name": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            }
-          },
-          "401": {
-            "description": "Request failed. User not signed in.",
-            "examples": {
-              "application/json": {
-                "message": "User not signed in."
-              }
-            },
-            "schema": {
-              "properties": {
-                "message": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            }
-          },
-          "403": {
-            "description": "Request failed. Credentials are invalid or revoked.",
-            "examples": {
-              "application/json": {
-                "message": "Token not valid."
-              }
-            },
-            "schema": {
-              "properties": {
-                "message": {
                   "type": "string"
                 }
               },
@@ -1500,7 +1471,7 @@
           {
             "description": "Required. UUID of workflow owner.",
             "in": "query",
-            "name": "user_id",
+            "name": "user",
             "required": true,
             "type": "string"
           },
@@ -1551,20 +1522,11 @@
             "description": "Request failed. The incoming data specification seems malformed.",
             "examples": {
               "application/json": {
-                "errors": [
-                  "Missing data for required field."
-                ],
                 "message": "Malformed request."
               }
             },
             "schema": {
               "properties": {
-                "errors": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
                 "message": {
                   "type": "string"
                 }
@@ -1576,9 +1538,7 @@
             "description": "Request failed. User is not allowed to unshare the workflow.",
             "examples": {
               "application/json": {
-                "errors": [
-                  "User is not allowed to unshare the workflow."
-                ]
+                "message": "User is not allowed to unshare the workflow."
               }
             },
             "schema": {
@@ -1594,20 +1554,11 @@
             "description": "Request failed. Workflow does not exist or user does not exist.",
             "examples": {
               "application/json": {
-                "errors": [
-                  "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
-                ],
                 "message": "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
               }
             },
             "schema": {
               "properties": {
-                "errors": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
                 "message": {
                   "type": "string"
                 }
@@ -1619,20 +1570,11 @@
             "description": "Request failed. The workflow is not shared with the user.",
             "examples": {
               "application/json": {
-                "errors": [
-                  "The workflow is not shared with the user."
-                ],
                 "message": "The workflow is not shared with the user."
               }
             },
             "schema": {
               "properties": {
-                "errors": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
                 "message": {
                   "type": "string"
                 }
@@ -1644,20 +1586,11 @@
             "description": "Request failed. Internal controller error.",
             "examples": {
               "application/json": {
-                "errors": [
-                  "Internal controller error."
-                ],
                 "message": "Internal controller error."
               }
             },
             "schema": {
               "properties": {
-                "errors": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
                 "message": {
                   "type": "string"
                 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -993,6 +993,111 @@
         "summary": "Get the retention rules of a workflow."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/share": {
+      "post": {
+        "description": "This resource allows to share a workflow with other users.",
+        "operationId": "share_workflow",
+        "parameters": [
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Analysis UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "JSON object with details of the share.",
+            "in": "body",
+            "name": "share_details",
+            "required": true,
+            "schema": {
+              "properties": {
+                "message": {
+                  "description": "Optional. Message to include when sharing the workflow.",
+                  "type": "string"
+                },
+                "user_email_to_share_with": {
+                  "description": "User to share the workflow with.",
+                  "type": "string"
+                },
+                "valid_until": {
+                  "description": "Optional. Date when access to the workflow will expire (format YYYY-MM-DD).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "user_email_to_share_with"
+              ],
+              "type": "object"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The workflow has been shared with the user.",
+            "examples": {
+              "application/json": {
+                "message": "The workflow has been shared with the user.",
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data seems malformed."
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist or user does not exist.",
+            "examples": {
+              "application/json": {
+                "message": "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+              }
+            }
+          },
+          "409": {
+            "description": "Request failed. The workflow is already shared with the user.",
+            "examples": {
+              "application/json": {
+                "message": "The workflow is already shared with the user."
+              }
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error.",
+            "examples": {
+              "application/json": {
+                "message": "Internal controller error."
+              }
+            }
+          }
+        },
+        "summary": "Share a workflow with other users."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/status": {
       "get": {
         "description": "This resource reports the status of workflow.",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1332,6 +1332,183 @@
         "summary": "Set workflow status."
       }
     },
+    "/api/workflows/{workflow_id_or_name}/unshare": {
+      "post": {
+        "description": "This resource allows to unshare a workflow with other users.",
+        "operationId": "unshare_workflow",
+        "parameters": [
+          {
+            "description": "Required. UUID of workflow owner.",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. Analysis UUID or name.",
+            "in": "path",
+            "name": "workflow_id_or_name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Required. User to unshare the workflow with.",
+            "in": "query",
+            "name": "user_email_to_unshare_with",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Request succeeded. The workflow has been unshared with the user.",
+            "examples": {
+              "application/json": {
+                "message": "The workflow has been unsahred with the user.",
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest.1"
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "workflow_id": {
+                  "type": "string"
+                },
+                "workflow_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Request failed. The incoming data specification seems malformed.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Missing data for required field."
+                ],
+                "message": "Malformed request."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "403": {
+            "description": "Request failed. User is not allowed to unshare the workflow.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "User is not allowed to unshare the workflow."
+                ]
+              }
+            },
+            "schema": {
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Request failed. Workflow does not exist or user does not exist.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+                ],
+                "message": "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does not exist"
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "409": {
+            "description": "Request failed. The workflow is not shared with the user.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "The workflow is not shared with the user."
+                ],
+                "message": "The workflow is not shared with the user."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Request failed. Internal controller error.",
+            "examples": {
+              "application/json": {
+                "errors": [
+                  "Internal controller error."
+                ],
+                "message": "Internal controller error."
+              }
+            },
+            "schema": {
+              "properties": {
+                "errors": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Unshare a workflow with other users."
+      }
+    },
     "/api/workflows/{workflow_id_or_name}/workspace": {
       "get": {
         "description": "This resource retrieves the file list of a workspace, given its workflow UUID.",

--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -275,3 +275,5 @@ The job controller needs to clean up all the running jobs before the end of the 
 
 CONTAINER_IMAGE_ALIAS_PREFIXES = ["docker.io/", "docker.io/library/", "library/"]
 """Prefixes that can be removed from container image references to generate valid image aliases."""
+
+MAX_WORKFLOW_SHARING_MESSAGE_LENGTH = 5000

--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -277,3 +277,4 @@ CONTAINER_IMAGE_ALIAS_PREFIXES = ["docker.io/", "docker.io/library/", "library/"
 """Prefixes that can be removed from container image references to generate valid image aliases."""
 
 MAX_WORKFLOW_SHARING_MESSAGE_LENGTH = 5000
+"""Maximum length of the user-provided message when sharing a workflow."""

--- a/reana_workflow_controller/factory.py
+++ b/reana_workflow_controller/factory.py
@@ -33,10 +33,15 @@ def handle_args_validation_error(error: UnprocessableEntity):
     exception = getattr(error, "exc", None)
     if isinstance(exception, ValidationError):
         validation_messages = []
-        for field, messages in exception.normalized_messages().items():
-            validation_messages.append(
-                "Field '{}': {}".format(field, ", ".join(messages))
-            )
+        # this is slightly different from r-server error handler due to different
+        # versions of webargs/marshmallow
+        # the format of normalized_messages() is:
+        # {"json": {"field name": ["error 1", "error 2"]}}
+        for field_messages in exception.normalized_messages().values():
+            for field, messages in field_messages.items():
+                validation_messages.append(
+                    "Field '{}': {}".format(field, ", ".join(messages))
+                )
         error_message = ". ".join(validation_messages)
 
     return jsonify({"message": error_message}), 400

--- a/reana_workflow_controller/rest/workflows.py
+++ b/reana_workflow_controller/rest/workflows.py
@@ -746,7 +746,7 @@ def get_workflow_parameters(workflow_id_or_name):  # noqa
 
     try:
         user_uuid = request.args["user"]
-        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_uuid)
+        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_uuid, True)
 
         workflow_parameters = workflow.get_input_parameters()
         return (
@@ -880,9 +880,13 @@ def get_workflow_diff(workflow_id_or_name_a, workflow_id_or_name_b):  # noqa
         context_lines = request.args.get("context_lines", 5)
 
         workflow_a_exists = False
-        workflow_a = _get_workflow_with_uuid_or_name(workflow_id_or_name_a, user_uuid)
+        workflow_a = _get_workflow_with_uuid_or_name(
+            workflow_id_or_name_a, user_uuid, True
+        )
         workflow_a_exists = True
-        workflow_b = _get_workflow_with_uuid_or_name(workflow_id_or_name_b, user_uuid)
+        workflow_b = _get_workflow_with_uuid_or_name(
+            workflow_id_or_name_b, user_uuid, True
+        )
         if not workflow_id_or_name_a or not workflow_id_or_name_b:
             raise ValueError("Workflow id or name is not supplied")
         specification_diff = get_specification_diff(workflow_a, workflow_b)
@@ -1014,7 +1018,7 @@ def get_workflow_retention_rules(workflow_id_or_name: str, user: str):
               }
     """
     try:
-        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user)
+        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user, True)
 
         rules = workflow.retention_rules.all()
         response = {

--- a/reana_workflow_controller/rest/workflows.py
+++ b/reana_workflow_controller/rest/workflows.py
@@ -1073,3 +1073,219 @@ def share_workflow(workflow_id_or_name: str, user: str):
     except Exception as e:
         logging.exception(str(e))
         return jsonify({"message": str(e)}), 500
+
+
+@blueprint.route("/workflows/<workflow_id_or_name>/unshare", methods=["POST"])
+@use_kwargs(
+    {
+        "user_id": fields.Str(required=True),
+        "user_email_to_unshare_with": fields.Str(required=True),
+    },
+    location="query",
+)
+def unshare_workflow(
+    workflow_id_or_name: str, user_id: str, user_email_to_unshare_with: str
+):
+    r"""Unshare a workflow with other users.
+
+    ---
+    post:
+      summary: Unshare a workflow with other users.
+      description: >-
+        This resource allows to unshare a workflow with other users.
+      operationId: unshare_workflow
+      produces:
+       - application/json
+      parameters:
+        - name: user_id
+          in: query
+          description: Required. UUID of workflow owner.
+          required: true
+          type: string
+        - name: workflow_id_or_name
+          in: path
+          description: Required. Analysis UUID or name.
+          required: true
+          type: string
+        - name: user_email_to_unshare_with
+          in: query
+          description: >-
+            Required. User to unshare the workflow with.
+          required: true
+          type: string
+      responses:
+        200:
+          description: >-
+            Request succeeded. The workflow has been unshared with the user.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+              workflow_id:
+                type: string
+              workflow_name:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "The workflow has been unsahred with the user.",
+                "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
+                "workflow_name": "mytest.1"
+              }
+        400:
+          description: >-
+            Request failed. The incoming data specification seems malformed.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+              errors:
+                type: array
+                items:
+                  type: string
+          examples:
+            application/json:
+              {
+                "message": "Malformed request.",
+                "errors": ["Missing data for required field."]
+              }
+        403:
+          description: >-
+            Request failed. User is not allowed to unshare the workflow.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "errors": ["User is not allowed to unshare the workflow."]
+              }
+        404:
+          description: >-
+            Request failed. Workflow does not exist or user does not exist.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+              errors:
+                type: array
+                items:
+                  type: string
+          examples:
+            application/json:
+              {
+                "message": "Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does
+                            not exist",
+                "errors": ["Workflow cdcf48b1-c2f3-4693-8230-b066e088c6ac does
+                            not exist"]
+              }
+        409:
+          description: >-
+            Request failed. The workflow is not shared with the user.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+              errors:
+                type: array
+                items:
+                  type: string
+          examples:
+            application/json:
+              {
+                "message": "The workflow is not shared with the user.",
+                "errors": ["The workflow is not shared with the user."]
+              }
+        500:
+          description: >-
+            Request failed. Internal controller error.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+              errors:
+                  type: array
+                  items:
+                    type: string
+          examples:
+            application/json:
+              {
+                "message": "Internal controller error.",
+                "errors": ["Internal controller error."]
+              }
+    """
+    try:
+        user = User.query.filter(User.id_ == user_id).first()
+        if not user:
+            return (
+                jsonify({"message": f"User with id '{user_id}' does not exist."}),
+                404,
+            )
+
+        if (
+            re.match(
+                r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b",
+                user_email_to_unshare_with,
+            )
+            is None
+        ):
+            raise ValueError(f"User email '{user_email_to_unshare_with}' is not valid.")
+
+        if user.email == user_email_to_unshare_with:
+            raise ValueError("Unable to unshare a workflow with yourself.")
+
+        user_to_unshare_with = (
+            Session.query(User).filter(User.email == user_email_to_unshare_with).first()
+        )
+
+        if not user_to_unshare_with:
+            return (
+                jsonify(
+                    {
+                        "message": f"User with email '{user_email_to_unshare_with}' does not exist."
+                    }
+                ),
+                404,
+            )
+
+        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, str(user_id))
+
+        existing_share = (
+            Session.query(UserWorkflow)
+            .filter_by(user_id=user_to_unshare_with.id_, workflow_id=workflow.id_)
+            .first()
+        )
+
+        if not existing_share:
+            return (
+                jsonify(
+                    {
+                        "message": f"{workflow.get_full_workflow_name()} is not shared with {user_email_to_unshare_with}."
+                    }
+                ),
+                409,
+            )
+
+        Session.delete(existing_share)
+        Session.commit()
+
+        response = {
+            "message": "The workflow has been unshared with the user.",
+            "workflow_id": workflow.id_,
+            "workflow_name": workflow.get_full_workflow_name(),
+        }
+
+        return jsonify(response), 200
+    except ValueError as e:
+        logging.exception(str(e))
+        return jsonify({"message": str(e)}), 400
+    except Exception as e:
+        logging.exception(str(e))
+        return jsonify({"message": str(e)}), 500

--- a/reana_workflow_controller/rest/workflows.py
+++ b/reana_workflow_controller/rest/workflows.py
@@ -1289,3 +1289,155 @@ def unshare_workflow(
     except Exception as e:
         logging.exception(str(e))
         return jsonify({"message": str(e)}), 500
+
+
+@blueprint.route("/workflows/<workflow_id_or_name>/share-status", methods=["GET"])
+@use_kwargs(
+    {
+        "user_id": fields.Str(required=True),
+    },
+    location="query",
+)
+def get_workflow_share_status(
+    workflow_id_or_name: str,
+    user_id: str,
+):
+    r"""Get the share status of a workflow.
+
+    ---
+    get:
+      summary: Get the share status of a workflow.
+      description: >-
+        This resource returns the share status of a given workflow.
+      operationId: get_workflow_share_status
+      produces:
+       - application/json
+      parameters:
+        - name: user_id
+          in: query
+          description: Required. UUID of workflow owner.
+          required: true
+          type: string
+        - name: workflow_id_or_name
+          in: path
+          description: Required. Workflow UUID or name.
+          required: true
+          type: string
+      responses:
+        200:
+          description: >-
+            Request succeeded. The response contains the share status of the workflow.
+          schema:
+            type: object
+            properties:
+              workflow_id:
+                type: string
+              workflow_name:
+                type: string
+              shared_with:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    user_email:
+                      type: string
+                    valid_until:
+                      type: string
+                      x-nullable: true
+          examples:
+            application/json:
+              {
+                "workflow_id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "workflow_name": "mytest.1",
+                "shared_with": [
+                    {
+                      "user_email": "bob@example.org",
+                      "valid_until": "2022-11-24T23:59:59"
+                    }
+                ]
+              }
+        401:
+          description: >-
+            Request failed. User not signed in.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "User not signed in."
+              }
+        403:
+          description: >-
+            Request failed. Credentials are invalid or revoked.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "Token not valid."
+              }
+        404:
+          description: >-
+            Request failed. Workflow does not exist.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "Workflow mytest.1 does not exist."
+              }
+        500:
+          description: >-
+            Request failed. Internal server error.
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+          examples:
+            application/json:
+              {
+                "message": "Something went wrong."
+              }
+    """
+    try:
+        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_id)
+
+        shared_with = (
+            Session.query(UserWorkflow)
+            .filter_by(workflow_id=workflow.id_)
+            .join(User, User.id_ == UserWorkflow.user_id)
+            .add_columns(User.email, UserWorkflow.valid_until)
+            .all()
+        )
+
+        response = {
+            "workflow_id": workflow.id_,
+            "workflow_name": workflow.get_full_workflow_name(),
+            "shared_with": [
+                {
+                    "user_email": share[1],
+                    "valid_until": (
+                        share[2].strftime("%Y-%m-%dT%H:%M:%S") if share[2] else None
+                    ),
+                }
+                for share in shared_with
+            ],
+        }
+
+        return jsonify(response), 200
+    except ValueError as e:
+        logging.exception(str(e))
+        return jsonify({"message": str(e)}), 404
+    except Exception as e:
+        logging.exception(str(e))
+        return jsonify({"message": str(e)}), 500

--- a/reana_workflow_controller/rest/workflows_status.py
+++ b/reana_workflow_controller/rest/workflows_status.py
@@ -138,7 +138,7 @@ def get_workflow_logs(workflow_id_or_name, paginate=None, **kwargs):  # noqa
     try:
         user_uuid = request.args["user"]
 
-        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_uuid)
+        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_uuid, True)
 
         steps = None
         if request.is_json:
@@ -278,7 +278,7 @@ def get_workflow_status(workflow_id_or_name):  # noqa
 
     try:
         user_uuid = request.args["user"]
-        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_uuid)
+        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_uuid, True)
         workflow_logs = build_workflow_logs(workflow)
 
         return (

--- a/reana_workflow_controller/rest/workflows_workspace.py
+++ b/reana_workflow_controller/rest/workflows_workspace.py
@@ -252,7 +252,7 @@ def download_file(workflow_id_or_name, file_name):  # noqa
         if not user:
             return jsonify({"message": "User {} does not exist".format(user)}), 404
 
-        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_uuid)
+        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_uuid, True)
         workflow_name = workflow.get_full_workflow_name()
 
         return download_files_recursive_wildcard(
@@ -474,7 +474,7 @@ def get_files(workflow_id_or_name, paginate=None):  # noqa
         if not user:
             return jsonify({"message": "User {} does not exist".format(user)}), 404
 
-        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_uuid)
+        workflow = _get_workflow_with_uuid_or_name(workflow_id_or_name, user_uuid, True)
         file_name = request.args.get("file_name")
         if search:
             search = json.loads(search)

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, kubernetes
 pytz==2024.1              # via bravado-core
 pyyaml==6.0.1             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
 reana-commons[kubernetes]==0.95.0a3  # via reana-db, reana-workflow-controller (setup.py)
-reana-db==0.95.0a3        # via reana-workflow-controller (setup.py)
+reana-db==0.95.0a4        # via reana-workflow-controller (setup.py)
 referencing==0.35.1       # via jsonschema, jsonschema-specifications
 requests==2.32.3          # via bravado, bravado-core, kubernetes, reana-workflow-controller (setup.py), requests-oauthlib
 requests-oauthlib==2.0.0  # via kubernetes

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extras_require = {
         "sphinxcontrib-redoc>=1.5.1",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a2,<0.96.0",
+        "pytest-reana>=0.95.0a4,<0.96.0",
     ],
 }
 
@@ -51,7 +51,7 @@ install_requires = [
     "marshmallow>2.13.0,<3.0.0",  # same upper pin as reana-server
     "packaging>=18.0",
     "reana-commons[kubernetes] @ git+https://github.com/reanahub/reana-commons.git@0.95.0a4",
-    "reana-db>=0.95.0a3,<0.96.0",
+    "reana-db>=0.95.0a4,<0.96.0",
     "requests>=2.25.0",
     "sqlalchemy-utils>=0.31.0",
     "uwsgi-tools>=1.1.1",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,8 +7,8 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 """REANA-Workflow-Controller utility tests."""
 
-import os
 import json
+import os
 import stat
 import uuid
 from contextlib import nullcontext as does_not_raise
@@ -18,12 +18,12 @@ from typing import ContextManager
 import mock
 import pytest
 from reana_db.models import (
+    InteractiveSession,
+    InteractiveSessionType,
     Job,
     JobCache,
     RunStatus,
     Workflow,
-    InteractiveSession,
-    InteractiveSessionType,
 )
 from reana_db.utils import (
     get_disk_usage_or_zero,
@@ -53,9 +53,7 @@ from reana_workflow_controller.rest.utils import (
         pytest.param(RunStatus.running, marks=pytest.mark.xfail(strict=True)),
     ],
 )
-def test_delete_workflow(
-    app, session, default_user, sample_yadage_workflow_in_db, status
-):
+def test_delete_workflow(app, session, user0, sample_yadage_workflow_in_db, status):
     """Test deletion of a workflow in all possible statuses."""
     sample_yadage_workflow_in_db.status = status
     session.add(sample_yadage_workflow_in_db)
@@ -65,16 +63,14 @@ def test_delete_workflow(
     assert sample_yadage_workflow_in_db.status == RunStatus.deleted
 
 
-def test_delete_all_workflow_runs(
-    app, session, default_user, yadage_workflow_with_name
-):
+def test_delete_all_workflow_runs(app, session, user0, yadage_workflow_with_name):
     """Test deletion of all runs of a given workflow."""
     # add 5 workflows in the database with the same name
     for i in range(5):
         workflow = Workflow(
             id_=uuid.uuid4(),
             name=yadage_workflow_with_name["name"],
-            owner_id=default_user.id_,
+            owner_id=user0.id_,
             reana_specification=yadage_workflow_with_name["reana_specification"],
             operational_options={},
             type_=yadage_workflow_with_name["reana_specification"]["workflow"]["type"],
@@ -138,7 +134,7 @@ def test_workspace_deletion(
     mock_update_workflow_quota,
     app,
     session,
-    default_user,
+    user0,
     sample_yadage_workflow_in_db,
     workspace,
 ):
@@ -206,7 +202,7 @@ def test_workspace_deletion(
 
 
 def test_deletion_of_workspace_of_an_already_deleted_workflow(
-    app, session, default_user, sample_yadage_workflow_in_db
+    app, session, user0, sample_yadage_workflow_in_db
 ):
     """Test workspace deletion of an already deleted workflow."""
     create_workflow_workspace(sample_yadage_workflow_in_db.workspace_path)
@@ -272,7 +268,7 @@ def test_list_recursive_wildcard(tmp_shared_volume_path):
 
 
 def test_workspace_permissions(
-    app, session, default_user, sample_yadage_workflow_in_db, tmp_shared_volume_path
+    app, session, user0, sample_yadage_workflow_in_db, tmp_shared_volume_path
 ):
     """Test workspace dir permissions."""
     create_workflow_workspace(sample_yadage_workflow_in_db.workspace_path)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -812,7 +812,7 @@ def test_get_workflow_status_unauthorized(
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
-        assert res.status_code == 404
+        assert res.status_code == 500
 
 
 def test_get_workflow_status_unknown_workflow(app, user0, cwl_workflow_with_name):
@@ -1027,7 +1027,7 @@ def test_set_workflow_status_unauthorized(
             query_string={"user": random_user_uuid, "status": payload},
             content_type="application/json",
         )
-        assert res.status_code == 404
+        assert res.status_code == 500
 
 
 def test_set_workflow_status_unknown_workflow(
@@ -1230,7 +1230,7 @@ def test_get_workflow_logs_unauthorized(
             query_string={"user": random_user_uuid},
             content_type="application/json",
         )
-        assert res.status_code == 404
+        assert res.status_code == 500
 
 
 def test_start_input_parameters(
@@ -1785,7 +1785,7 @@ def test_get_workflow_retention_rules_invalid_user(app, sample_serial_workflow_i
             ),
             query_string={"user": uuid.uuid4()},
         )
-        assert res.status_code == 404
+        assert res.status_code == 500
 
 
 def test_share_workflow(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -39,7 +39,7 @@ status_dict = {
 }
 
 
-def test_get_workflows(app, session, default_user, cwl_workflow_with_name):
+def test_get_workflows(app, session, user0, cwl_workflow_with_name):
     """Test listing all workflows."""
     with app.test_client() as client:
         workflow_uuid = uuid.uuid4()
@@ -48,7 +48,7 @@ def test_get_workflows(app, session, default_user, cwl_workflow_with_name):
             id_=workflow_uuid,
             name=workflow_name,
             status=RunStatus.finished,
-            owner_id=default_user.id_,
+            owner_id=user0.id_,
             reana_specification=cwl_workflow_with_name["reana_specification"],
             type_=cwl_workflow_with_name["reana_specification"]["type"],
             logs="",
@@ -57,7 +57,7 @@ def test_get_workflows(app, session, default_user, cwl_workflow_with_name):
         session.commit()
         res = client.get(
             url_for("workflows.get_workflows"),
-            query_string={"user": default_user.id_, "type": "batch"},
+            query_string={"user": user0.id_, "type": "batch"},
         )
         assert res.status_code == 200
         response_data = json.loads(res.get_data(as_text=True))["items"]
@@ -97,25 +97,23 @@ def test_get_workflows_missing_user(app):
         assert res.status_code == 400
 
 
-def test_get_workflows_missing_type(app, default_user):
+def test_get_workflows_missing_type(app, user0):
     """Test listing all workflows with missing type."""
     with app.test_client() as client:
         res = client.get(
-            url_for("workflows.get_workflows"), query_string={"user": default_user.id_}
+            url_for("workflows.get_workflows"), query_string={"user": user0.id_}
         )
         assert res.status_code == 400
 
 
-def test_get_workflows_include_progress(
-    app, default_user, sample_yadage_workflow_in_db
-):
+def test_get_workflows_include_progress(app, user0, sample_yadage_workflow_in_db):
     """Test listing all workflows without including progress."""
     workflow = sample_yadage_workflow_in_db
     with app.test_client() as client:
         res = client.get(
             url_for("workflows.get_workflows"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "type": "batch",
                 "verbose": "true",
                 "include_progress": "false",
@@ -129,7 +127,7 @@ def test_get_workflows_include_progress(
 
 
 def test_get_workflows_include_retention_rules(
-    app, default_user, sample_yadage_workflow_in_db
+    app, user0, sample_yadage_workflow_in_db
 ):
     """Test listing all workflows without including retention rules."""
     workflow = sample_yadage_workflow_in_db
@@ -137,7 +135,7 @@ def test_get_workflows_include_retention_rules(
         res = client.get(
             url_for("workflows.get_workflows"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "type": "batch",
                 "verbose": "true",
                 "include_retention_rules": "false",
@@ -150,14 +148,14 @@ def test_get_workflows_include_retention_rules(
 
 
 def test_create_workflow_with_name(
-    app, session, default_user, cwl_workflow_with_name, tmp_shared_volume_path
+    app, session, user0, cwl_workflow_with_name, tmp_shared_volume_path
 ):
     """Test create workflow and its workspace by specifying a name."""
     with app.test_client() as client:
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -185,14 +183,14 @@ def test_create_workflow_with_name(
 
 
 def test_create_workflow_without_name(
-    app, session, default_user, cwl_workflow_without_name, tmp_shared_volume_path
+    app, session, user0, cwl_workflow_without_name, tmp_shared_volume_path
 ):
     """Test create workflow and its workspace without specifying a name."""
     with app.test_client() as client:
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -254,7 +252,7 @@ def test_create_workflow_wrong_user(
 
 
 def test_download_missing_file(
-    app, default_user, cwl_workflow_with_name, tmp_shared_volume_path
+    app, user0, cwl_workflow_with_name, tmp_shared_volume_path
 ):
     """Test download missing file."""
     with app.test_client() as client:
@@ -262,7 +260,7 @@ def test_download_missing_file(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -279,7 +277,7 @@ def test_download_missing_file(
                 workflow_id_or_name=workflow_uuid,
                 file_name=file_name,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -292,7 +290,7 @@ def test_download_missing_file(
 def test_download_file(
     app,
     session,
-    default_user,
+    user0,
     tmp_shared_volume_path,
     cwl_workflow_with_name,
     sample_serial_workflow_in_db,
@@ -303,7 +301,7 @@ def test_download_file(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -332,7 +330,7 @@ def test_download_file(
                 workflow_id_or_name=workflow_uuid,
                 file_name=file_name,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -340,7 +338,7 @@ def test_download_file(
 
 
 def test_download_file_with_path(
-    app, session, default_user, tmp_shared_volume_path, cwl_workflow_with_name
+    app, session, user0, tmp_shared_volume_path, cwl_workflow_with_name
 ):
     """Test download file prepended with path."""
     with app.test_client() as client:
@@ -348,7 +346,7 @@ def test_download_file_with_path(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -376,7 +374,7 @@ def test_download_file_with_path(
                 workflow_id_or_name=workflow_uuid,
                 file_name=file_name,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -384,7 +382,7 @@ def test_download_file_with_path(
 
 
 def test_download_dir_or_wildcard(
-    app, session, default_user, tmp_shared_volume_path, cwl_workflow_with_name
+    app, session, user0, tmp_shared_volume_path, cwl_workflow_with_name
 ):
     """Test download directory or file(s) matching a wildcard pattern."""
 
@@ -395,7 +393,7 @@ def test_download_dir_or_wildcard(
                 workflow_id_or_name=workflow_uuid,
                 file_name=pattern,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -405,7 +403,7 @@ def test_download_dir_or_wildcard(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -458,16 +456,14 @@ def test_download_dir_or_wildcard(
         assert res.data == files["foo/1.txt"]
 
 
-def test_get_files(
-    app, session, default_user, tmp_shared_volume_path, cwl_workflow_with_name
-):
+def test_get_files(app, session, user0, tmp_shared_volume_path, cwl_workflow_with_name):
     """Test get files list."""
     with app.test_client() as client:
         # create workflow
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -491,7 +487,7 @@ def test_get_files(
 
         res = client.get(
             url_for("workspaces.get_files", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -500,7 +496,7 @@ def test_get_files(
 
 
 def test_get_files_deleted_workflow(
-    app, default_user, tmp_shared_volume_path, cwl_workflow_with_name
+    app, user0, tmp_shared_volume_path, cwl_workflow_with_name
 ):
     """Test get files list of a deleted workflow without a workspace."""
     with app.test_client() as client:
@@ -508,7 +504,7 @@ def test_get_files_deleted_workflow(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -524,7 +520,7 @@ def test_get_files_deleted_workflow(
                 "statuses.set_workflow_status",
                 workflow_id_or_name=workflow_uuid,
             ),
-            query_string={"user": default_user.id_, "status": "deleted"},
+            query_string={"user": user0.id_, "status": "deleted"},
             content_type="application/json",
             data=json.dumps({}),
         )
@@ -537,20 +533,20 @@ def test_get_files_deleted_workflow(
         # get list of files
         res = client.get(
             url_for("workspaces.get_files", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
         assert res.status_code == 404
 
 
-def test_get_files_unknown_workflow(app, default_user):
+def test_get_files_unknown_workflow(app, user0):
     """Test get list of files for non existing workflow."""
     with app.test_client() as client:
         # create workflow
         random_workflow_uuid = str(uuid.uuid4())
         res = client.get(
             url_for("workspaces.get_files", workflow_id_or_name=random_workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
 
@@ -566,7 +562,7 @@ def test_get_files_unknown_workflow(app, default_user):
 
 
 def test_get_workflow_status_with_uuid(
-    app, session, default_user, cwl_workflow_with_name, tmp_shared_volume_path
+    app, session, user0, cwl_workflow_with_name, tmp_shared_volume_path
 ):
     """Test get workflow status."""
     with app.test_client() as client:
@@ -574,7 +570,7 @@ def test_get_workflow_status_with_uuid(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -587,7 +583,7 @@ def test_get_workflow_status_with_uuid(
 
         res = client.get(
             url_for("statuses.get_workflow_status", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -598,7 +594,7 @@ def test_get_workflow_status_with_uuid(
 
         res = client.get(
             url_for("statuses.get_workflow_status", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -606,9 +602,7 @@ def test_get_workflow_status_with_uuid(
         assert json_response.get("status") == workflow.status.name
 
 
-def test_get_workflow_status_with_name(
-    app, session, default_user, cwl_workflow_with_name
-):
+def test_get_workflow_status_with_name(app, session, user0, cwl_workflow_with_name):
     """Test get workflow status."""
     with app.test_client() as client:
         # create workflow
@@ -618,7 +612,7 @@ def test_get_workflow_status_with_name(
             id_=workflow_uuid,
             name=workflow_name,
             status=RunStatus.finished,
-            owner_id=default_user.id_,
+            owner_id=user0.id_,
             reana_specification=cwl_workflow_with_name["reana_specification"],
             type_=cwl_workflow_with_name["reana_specification"]["type"],
             logs="",
@@ -632,7 +626,7 @@ def test_get_workflow_status_with_name(
             url_for(
                 "statuses.get_workflow_status", workflow_id_or_name=workflow_name + ".1"
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -646,7 +640,7 @@ def test_get_workflow_status_with_name(
             url_for(
                 "statuses.get_workflow_status", workflow_id_or_name=workflow_name + ".1"
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -655,7 +649,7 @@ def test_get_workflow_status_with_name(
 
 
 def test_get_workflow_status_unauthorized(
-    app, default_user, cwl_workflow_with_name, tmp_shared_volume_path
+    app, user0, cwl_workflow_with_name, tmp_shared_volume_path
 ):
     """Test get workflow status unauthorized."""
     with app.test_client() as client:
@@ -663,7 +657,7 @@ def test_get_workflow_status_unauthorized(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -685,15 +679,13 @@ def test_get_workflow_status_unauthorized(
         assert res.status_code == 404
 
 
-def test_get_workflow_status_unknown_workflow(
-    app, default_user, cwl_workflow_with_name
-):
+def test_get_workflow_status_unknown_workflow(app, user0, cwl_workflow_with_name):
     """Test get workflow status for unknown workflow."""
     with app.test_client() as client:
         # create workflow
         res = client.post(
             url_for("workflows.create_workflow"),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -702,7 +694,7 @@ def test_get_workflow_status_unknown_workflow(
             url_for(
                 "statuses.get_workflow_status", workflow_id_or_name=random_workflow_uuid
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(cwl_workflow_with_name),
         )
@@ -714,7 +706,7 @@ def test_set_workflow_status(
     corev1_api_client_with_user_secrets,
     user_secrets,
     session,
-    default_user,
+    user0,
     yadage_workflow_with_name,
     tmp_shared_volume_path,
 ):
@@ -724,7 +716,7 @@ def test_set_workflow_status(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -751,7 +743,7 @@ def test_set_workflow_status(
                         "statuses.set_workflow_status",
                         workflow_id_or_name=workflow_created_uuid,
                     ),
-                    query_string={"user": default_user.id_, "status": "start"},
+                    query_string={"user": user0.id_, "status": "start"},
                 )
                 json_response = json.loads(res.data.decode())
                 assert json_response.get("status") == status_dict[payload].name
@@ -761,7 +753,7 @@ def test_set_workflow_status(
 def test_start_already_started_workflow(
     app,
     session,
-    default_user,
+    user0,
     corev1_api_client_with_user_secrets,
     user_secrets,
     yadage_workflow_with_name,
@@ -774,7 +766,7 @@ def test_start_already_started_workflow(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -801,7 +793,7 @@ def test_start_already_started_workflow(
                         "statuses.set_workflow_status",
                         workflow_id_or_name=workflow_created_uuid,
                     ),
-                    query_string={"user": default_user.id_, "status": "start"},
+                    query_string={"user": user0.id_, "status": "start"},
                 )
                 json_response = json.loads(res.data.decode())
                 assert json_response.get("status") == status_dict[payload].name
@@ -810,7 +802,7 @@ def test_start_already_started_workflow(
                         "statuses.set_workflow_status",
                         workflow_id_or_name=workflow_created_uuid,
                     ),
-                    query_string={"user": default_user.id_, "status": "start"},
+                    query_string={"user": user0.id_, "status": "start"},
                 )
                 json_response = json.loads(res.data.decode())
                 assert res.status_code == 409
@@ -838,7 +830,7 @@ def test_stop_workflow(
     k8s_stop_call_count,
     should_update_logs,
     app,
-    default_user,
+    user0,
     yadage_workflow_with_name,
     sample_serial_workflow_in_db,
     session,
@@ -860,7 +852,7 @@ def test_stop_workflow(
                     "statuses.set_workflow_status",
                     workflow_id_or_name=sample_serial_workflow_in_db.name,
                 ),
-                query_string={"user": default_user.id_, "status": "stop"},
+                query_string={"user": user0.id_, "status": "stop"},
             )
             assert sample_serial_workflow_in_db.status == expected_status
             assert res.status_code == expected_http_status_code
@@ -872,7 +864,7 @@ def test_stop_workflow(
 
 
 def test_set_workflow_status_unauthorized(
-    app, default_user, yadage_workflow_with_name, tmp_shared_volume_path
+    app, user0, yadage_workflow_with_name, tmp_shared_volume_path
 ):
     """Test set workflow status unauthorized."""
     with app.test_client() as client:
@@ -880,7 +872,7 @@ def test_set_workflow_status_unauthorized(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -903,7 +895,7 @@ def test_set_workflow_status_unauthorized(
 
 
 def test_set_workflow_status_unknown_workflow(
-    app, default_user, yadage_workflow_with_name, tmp_shared_volume_path
+    app, user0, yadage_workflow_with_name, tmp_shared_volume_path
 ):
     """Test set workflow status for unknown workflow."""
     with app.test_client() as client:
@@ -911,7 +903,7 @@ def test_set_workflow_status_unknown_workflow(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -923,7 +915,7 @@ def test_set_workflow_status_unknown_workflow(
             url_for(
                 "statuses.set_workflow_status", workflow_id_or_name=random_workflow_uuid
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(payload),
         )
@@ -931,7 +923,7 @@ def test_set_workflow_status_unknown_workflow(
 
 
 def test_upload_file(
-    app, session, default_user, tmp_shared_volume_path, cwl_workflow_with_name
+    app, session, user0, tmp_shared_volume_path, cwl_workflow_with_name
 ):
     """Test upload file."""
     with app.test_client() as client:
@@ -939,7 +931,7 @@ def test_upload_file(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -955,7 +947,7 @@ def test_upload_file(
 
         res = client.post(
             url_for("workspaces.upload_file", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_, "file_name": file_name},
+            query_string={"user": user0.id_, "file_name": file_name},
             content_type="application/octet-stream",
             input_stream=io.BytesIO(file_binary_content),
         )
@@ -974,7 +966,7 @@ def test_upload_file(
             assert f.read() == file_binary_content
 
 
-def test_upload_file_unknown_workflow(app, default_user):
+def test_upload_file_unknown_workflow(app, user0):
     """Test upload file to non existing workflow."""
     with app.test_client() as client:
         random_workflow_uuid = uuid.uuid4()
@@ -984,14 +976,14 @@ def test_upload_file_unknown_workflow(app, default_user):
 
         res = client.post(
             url_for("workspaces.upload_file", workflow_id_or_name=random_workflow_uuid),
-            query_string={"user": default_user.id_, "file_name": file_name},
+            query_string={"user": user0.id_, "file_name": file_name},
             content_type="application/octet-stream",
             input_stream=io.BytesIO(file_binary_content),
         )
         assert res.status_code == 404
 
 
-def test_delete_file(app, default_user, sample_serial_workflow_in_db):
+def test_delete_file(app, user0, sample_serial_workflow_in_db):
     """Test delete file."""
     # Move to fixture
     from flask import current_app
@@ -1012,14 +1004,14 @@ def test_delete_file(app, default_user, sample_serial_workflow_in_db):
                 workflow_id_or_name=sample_serial_workflow_in_db.id_,
                 file_name=file_name,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
         )
         assert res.status_code == 200
         assert not os.path.exists(abs_path_to_file)
 
 
 def test_get_created_workflow_logs(
-    app, default_user, cwl_workflow_with_name, tmp_shared_volume_path
+    app, user0, cwl_workflow_with_name, tmp_shared_volume_path
 ):
     """Test get workflow logs."""
     with app.test_client() as client:
@@ -1027,7 +1019,7 @@ def test_get_created_workflow_logs(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -1038,7 +1030,7 @@ def test_get_created_workflow_logs(
         workflow_name = response_data.get("workflow_name")
         res = client.get(
             url_for("statuses.get_workflow_logs", workflow_id_or_name=workflow_uuid),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
             data=json.dumps(None),
         )
@@ -1047,14 +1039,14 @@ def test_get_created_workflow_logs(
         expected_data = {
             "workflow_id": workflow_uuid,
             "workflow_name": workflow_name,
-            "user": str(default_user.id_),
+            "user": str(user0.id_),
             "logs": '{"workflow_logs": "", "job_logs": {},' ' "engine_specific": null}',
         }
         assert response_data == expected_data
 
 
 def test_get_unknown_workflow_logs(
-    app, default_user, yadage_workflow_with_name, tmp_shared_volume_path
+    app, user0, yadage_workflow_with_name, tmp_shared_volume_path
 ):
     """Test set workflow status for unknown workflow."""
     with app.test_client() as client:
@@ -1062,7 +1054,7 @@ def test_get_unknown_workflow_logs(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -1073,14 +1065,14 @@ def test_get_unknown_workflow_logs(
             url_for(
                 "statuses.get_workflow_logs", workflow_id_or_name=random_workflow_uuid
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
         assert res.status_code == 404
 
 
 def test_get_workflow_logs_unauthorized(
-    app, default_user, yadage_workflow_with_name, tmp_shared_volume_path
+    app, user0, yadage_workflow_with_name, tmp_shared_volume_path
 ):
     """Test set workflow status for unknown workflow."""
     with app.test_client() as client:
@@ -1088,7 +1080,7 @@ def test_get_workflow_logs_unauthorized(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -1108,7 +1100,7 @@ def test_get_workflow_logs_unauthorized(
 def test_start_input_parameters(
     app,
     session,
-    default_user,
+    user0,
     user_secrets,
     corev1_api_client_with_user_secrets,
     sample_serial_workflow_in_db,
@@ -1139,7 +1131,7 @@ def test_start_input_parameters(
                         "statuses.set_workflow_status",
                         workflow_id_or_name=workflow_created_uuid,
                     ),
-                    query_string={"user": default_user.id_, "status": "start"},
+                    query_string={"user": user0.id_, "status": "start"},
                     content_type="application/json",
                     data=json.dumps(parameters),
                 )
@@ -1154,7 +1146,7 @@ def test_start_input_parameters(
 def test_start_workflow_db_failure(
     app,
     session,
-    default_user,
+    user0,
     sample_serial_workflow_in_db,
 ):
     """Test starting workflow with a DB failure."""
@@ -1180,7 +1172,7 @@ def test_start_workflow_db_failure(
                     "statuses.set_workflow_status",
                     workflow_id_or_name=sample_serial_workflow_in_db.id_,
                 ),
-                query_string={"user": default_user.id_, "status": "start"},
+                query_string={"user": user0.id_, "status": "start"},
                 content_type="application/json",
                 data=json.dumps({}),
             )
@@ -1190,7 +1182,7 @@ def test_start_workflow_db_failure(
 def test_start_workflow_kubernetes_failure(
     app,
     session,
-    default_user,
+    user0,
     sample_serial_workflow_in_db,
 ):
     """Test starting workflow with a Kubernetes failure when creating jobs."""
@@ -1212,7 +1204,7 @@ def test_start_workflow_kubernetes_failure(
                     "statuses.set_workflow_status",
                     workflow_id_or_name=sample_serial_workflow_in_db.id_,
                 ),
-                query_string={"user": default_user.id_, "status": "start"},
+                query_string={"user": user0.id_, "status": "start"},
                 content_type="application/json",
                 data=json.dumps({}),
             )
@@ -1229,9 +1221,7 @@ def test_start_workflow_kubernetes_failure(
         pytest.param(RunStatus.running, marks=pytest.mark.xfail(strict=True)),
     ],
 )
-def test_delete_workflow(
-    app, session, default_user, sample_yadage_workflow_in_db, status
-):
+def test_delete_workflow(app, session, user0, sample_yadage_workflow_in_db, status):
     """Test deletion of a workflow in all possible statuses."""
     sample_yadage_workflow_in_db.status = status
     session.add(sample_yadage_workflow_in_db)
@@ -1242,23 +1232,21 @@ def test_delete_workflow(
                 "statuses.set_workflow_status",
                 workflow_id_or_name=sample_yadage_workflow_in_db.id_,
             ),
-            query_string={"user": default_user.id_, "status": "deleted"},
+            query_string={"user": user0.id_, "status": "deleted"},
             content_type="application/json",
             data=json.dumps({}),
         )
         assert sample_yadage_workflow_in_db.status == RunStatus.deleted
 
 
-def test_delete_all_workflow_runs(
-    app, session, default_user, yadage_workflow_with_name
-):
+def test_delete_all_workflow_runs(app, session, user0, yadage_workflow_with_name):
     """Test deletion of all runs of a given workflow."""
     # add 5 workflows in the database with the same name
     for i in range(5):
         workflow = Workflow(
             id_=uuid.uuid4(),
             name=yadage_workflow_with_name["name"],
-            owner_id=default_user.id_,
+            owner_id=user0.id_,
             reana_specification=yadage_workflow_with_name["reana_specification"],
             operational_options={},
             type_=yadage_workflow_with_name["reana_specification"]["workflow"]["type"],
@@ -1277,7 +1265,7 @@ def test_delete_all_workflow_runs(
             url_for(
                 "statuses.set_workflow_status", workflow_id_or_name=first_workflow.id_
             ),
-            query_string={"user": default_user.id_, "status": "deleted"},
+            query_string={"user": user0.id_, "status": "deleted"},
             content_type="application/json",
             data=json.dumps({"all_runs": True}),
         )
@@ -1291,7 +1279,7 @@ def test_delete_all_workflow_runs(
 def test_workspace_deletion(
     app,
     session,
-    default_user,
+    user0,
     yadage_workflow_with_name,
     tmp_shared_volume_path,
     workspace,
@@ -1301,7 +1289,7 @@ def test_workspace_deletion(
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -1330,7 +1318,7 @@ def test_workspace_deletion(
                 url_for(
                     "statuses.set_workflow_status", workflow_id_or_name=workflow.id_
                 ),
-                query_string={"user": default_user.id_, "status": "deleted"},
+                query_string={"user": user0.id_, "status": "deleted"},
                 content_type="application/json",
                 data=json.dumps({"workspace": workspace}),
             )
@@ -1347,14 +1335,14 @@ def test_workspace_deletion(
 
 
 def test_deletion_of_workspace_of_an_already_deleted_workflow(
-    app, session, default_user, yadage_workflow_with_name, tmp_shared_volume_path
+    app, session, user0, yadage_workflow_with_name, tmp_shared_volume_path
 ):
     """Test workspace deletion of an already deleted workflow."""
     with app.test_client() as client:
         res = client.post(
             url_for("workflows.create_workflow"),
             query_string={
-                "user": default_user.id_,
+                "user": user0.id_,
                 "workspace_root_path": tmp_shared_volume_path,
             },
             content_type="application/json",
@@ -1375,7 +1363,7 @@ def test_deletion_of_workspace_of_an_already_deleted_workflow(
                 url_for(
                     "statuses.set_workflow_status", workflow_id_or_name=workflow.id_
                 ),
-                query_string={"user": default_user.id_, "status": "deleted"},
+                query_string={"user": user0.id_, "status": "deleted"},
                 content_type="application/json",
                 data=json.dumps({"workspace": False}),
             )
@@ -1387,7 +1375,7 @@ def test_deletion_of_workspace_of_an_already_deleted_workflow(
 
 def test_get_workflow_diff(
     app,
-    default_user,
+    user0,
     sample_yadage_workflow_in_db,
     sample_serial_workflow_in_db,
     tmp_shared_volume_path,
@@ -1400,7 +1388,7 @@ def test_get_workflow_diff(
                 workflow_id_or_name_a=sample_serial_workflow_in_db.id_,
                 workflow_id_or_name_b=sample_yadage_workflow_in_db.id_,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
         assert res.status_code == 200
@@ -1437,7 +1425,7 @@ def test_get_workflow_diff(
 
 def test_get_workspace_diff(
     app,
-    default_user,
+    user0,
     sample_yadage_workflow_in_db,
     sample_serial_workflow_in_db,
     tmp_shared_volume_path,
@@ -1465,7 +1453,7 @@ def test_get_workspace_diff(
                 workflow_id_or_name_a=sample_serial_workflow_in_db.id_,
                 workflow_id_or_name_b=sample_yadage_workflow_in_db.id_,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
         assert res.status_code == 200
@@ -1474,7 +1462,7 @@ def test_get_workspace_diff(
 
 
 def test_create_interactive_session(
-    app, default_user, sample_serial_workflow_in_db, interactive_session_environments
+    app, user0, sample_serial_workflow_in_db, interactive_session_environments
 ):
     """Test create interactive session."""
     wrm = WorkflowRunManager(sample_serial_workflow_in_db)
@@ -1494,13 +1482,13 @@ def test_create_interactive_session(
                     workflow_id_or_name=sample_serial_workflow_in_db.id_,
                     interactive_session_type="jupyter",
                 ),
-                query_string={"user": default_user.id_},
+                query_string={"user": user0.id_},
             )
             assert res.json == expected_data
 
 
 def test_create_interactive_session_unknown_type(
-    app, default_user, sample_serial_workflow_in_db, interactive_session_environments
+    app, user0, sample_serial_workflow_in_db, interactive_session_environments
 ):
     """Test create interactive session for unknown interactive type."""
     with app.test_client() as client:
@@ -1511,13 +1499,13 @@ def test_create_interactive_session_unknown_type(
                 workflow_id_or_name=sample_serial_workflow_in_db.id_,
                 interactive_session_type="terminal",
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
         )
         assert res.status_code == 404
 
 
 def test_create_interactive_session_custom_image(
-    app, default_user, sample_serial_workflow_in_db, interactive_session_environments
+    app, user0, sample_serial_workflow_in_db, interactive_session_environments
 ):
     """Create an interactive session with custom image."""
     custom_image = "docker_image_2"
@@ -1537,7 +1525,7 @@ def test_create_interactive_session_custom_image(
                     workflow_id_or_name=sample_serial_workflow_in_db.id_,
                     interactive_session_type="jupyter",
                 ),
-                query_string={"user": default_user.id_},
+                query_string={"user": user0.id_},
                 content_type="application/json",
                 data=json.dumps(interactive_session_configuration),
             )
@@ -1547,9 +1535,7 @@ def test_create_interactive_session_custom_image(
             assert fargs[1].spec.template.spec.containers[0].image == custom_image
 
 
-def test_close_interactive_session(
-    app, session, default_user, sample_serial_workflow_in_db
-):
+def test_close_interactive_session(app, session, user0, sample_serial_workflow_in_db):
     """Test close an interactive session."""
     expected_data = {"message": "The interactive session has been closed"}
     path = "/5d9b30fd-f225-4615-9107-b1373afec070"
@@ -1571,14 +1557,14 @@ def test_close_interactive_session(
                     "workflows_session.close_interactive_session",
                     workflow_id_or_name=sample_serial_workflow_in_db.id_,
                 ),
-                query_string={"user": default_user.id_},
+                query_string={"user": user0.id_},
                 content_type="application/json",
             )
         assert res.json == expected_data
 
 
 def test_close_interactive_session_not_opened(
-    app, session, default_user, sample_serial_workflow_in_db
+    app, session, user0, sample_serial_workflow_in_db
 ):
     """Test close an interactive session when session is not opened."""
     expected_data = {
@@ -1595,7 +1581,7 @@ def test_close_interactive_session_not_opened(
                 "workflows_session.close_interactive_session",
                 workflow_id_or_name=sample_serial_workflow_in_db.id_,
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
             content_type="application/json",
         )
         assert res.json == expected_data
@@ -1638,7 +1624,7 @@ def test_get_workflow_retention_rules_no_rules(app, sample_serial_workflow_in_db
         assert res.json["retention_rules"] == []
 
 
-def test_get_workflow_retention_rules_invalid_workflow(app, default_user):
+def test_get_workflow_retention_rules_invalid_workflow(app, user0):
     """Test get_workflow_retention_rules for invalid workflow."""
     with app.test_client() as client:
         res = client.get(
@@ -1646,7 +1632,7 @@ def test_get_workflow_retention_rules_invalid_workflow(app, default_user):
                 "workflows.get_workflow_retention_rules",
                 workflow_id_or_name="invalid_name",
             ),
-            query_string={"user": default_user.id_},
+            query_string={"user": user0.id_},
         )
         assert res.status_code == 404
         assert b"invalid_name" in res.data


### PR DESCRIPTION
| Command               | Allowed   |
|-----------------------|-----------|
| delete            | ❌        |
| diff                | ✅        |
| logs                  | ✅        |
| restart           | ❌        |
| start             | ❌        |
| status              | ✅        |
| stop              | ❌        |
| share-add         | ❌        |
| share-remove      | ❌        |
| share-status      | ❌        |
| close            | ❌        |
| open              | ❌        |
| download            | ✅        |
| du                  | ✅        |
| ls                   | ✅        |
| mv                 | ❌        |
| prune             | ❌        |
| rm              | ❌        |
| upload            | ❌        |
| retention-rules-list| ✅        |

Closes reanahub/reana-server#651, closes reanahub/reana-server#650