### PR TITLE
fix(manager): use valid group name when calling `groupadd` (#566)

### DIFF
--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -27,6 +27,7 @@ from reana_commons.config import (
     REANA_RUNTIME_JOBS_KUBERNETES_NODE_LABEL,
     REANA_RUNTIME_KUBERNETES_SERVICEACCOUNT_NAME,
     REANA_STORAGE_BACKEND,
+    WORKFLOW_RUNTIME_GROUP_NAME,
     WORKFLOW_RUNTIME_USER_GID,
     WORKFLOW_RUNTIME_USER_NAME,
     WORKFLOW_RUNTIME_USER_UID,
@@ -700,8 +701,10 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         """Create job controller startup cmd."""
         base_cmd = "exec flask run -h 0.0.0.0;"
         if user:
-            add_group_cmd = "groupadd -f -g {} {};".format(
-                WORKFLOW_RUNTIME_USER_GID, WORKFLOW_RUNTIME_USER_GID
+            add_group_cmd = (
+                "getent group '{gid}' || groupadd -f -g '{gid}' '{name}';".format(
+                    gid=WORKFLOW_RUNTIME_USER_GID, name=WORKFLOW_RUNTIME_GROUP_NAME
+                )
             )
             add_user_cmd = "useradd -u {} -g {} -M {};".format(
                 WORKFLOW_RUNTIME_USER_UID, WORKFLOW_RUNTIME_USER_GID, user

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ pyrsistent==0.20.0        # via jsonschema
 python-dateutil==2.8.2    # via bravado, bravado-core, kubernetes
 pytz==2023.3.post1        # via bravado-core
 pyyaml==6.0.1             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.9.4  # via reana-commons, reana-db, reana-workflow-controller (setup.py)
+reana-commons[kubernetes]==0.9.6  # via reana-commons, reana-db, reana-workflow-controller (setup.py)
 reana-db==0.9.3           # via reana-workflow-controller (setup.py)
 requests==2.25.0          # via bravado, bravado-core, kubernetes, reana-workflow-controller (setup.py), requests-oauthlib
 requests-oauthlib==1.3.1  # via kubernetes

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ install_requires = [
     "jsonpickle>=0.9.6",
     "marshmallow>2.13.0,<=2.20.1",
     "packaging>=18.0",
-    "reana-commons[kubernetes]>=0.9.4,<0.10.0",
+    "reana-commons[kubernetes]>=0.9.6,<0.10.0",
     "reana-db>=0.9.3,<0.10.0",
     "requests==2.25.0",
     "sqlalchemy-utils>=0.31.0",


### PR DESCRIPTION
Use a valid name when creating a new group with `groupadd`, as numbers
are not valid group names.

Closes #561
