### PR TITLE
ci(commitlint): allow release commit style

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -58,6 +58,8 @@ check_commitlint () {
     while IFS= read -r line; do
         if echo "$line" | grep -qP "\(\#$pr\)$"; then
             true
+        elif echo "$line" | grep -qP "^chore\(.*\): release"; then
+            true
         else
             echo "✖   Headline does not end by '(#$pr)' PR number: $line"
             found=1


### PR DESCRIPTION
Allow unconventional commit style for the chore release commits created by Release Please.