### PR TITLE
fix(docker): explicitly specify shell (#598)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@
 # Use Ubuntu LTS base image
 FROM docker.io/library/ubuntu:24.04
 
+# Configure shell options
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Use default answers in installation commands
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Fix the `JSONArgsRecommended` warning by explicitly setting the shell to
be used when running the Dockerfile's `CMD` command. Note that it is not
possible to switch to the exec form of `CMD`, as it lacks environment
variable expansion.

Closes #596
