### PR TITLE
build(docker): pin setuptools 70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<71' py
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
@@ -152,7 +152,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<71' py
           pip install twine wheel
           pip install -e .[all]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -31,7 +31,7 @@ RUN apt-get update -y && \
       python3.8 \
       python3.8-dev \
       vim-tiny && \
-    pip install --no-cache-dir --upgrade pip setuptools && \
+    pip install --no-cache-dir --upgrade pip 'setuptools<71' && \
     pip install --no-cache-dir -r /code/requirements.txt && \
     apt-get remove -y \
       gcc \


### PR DESCRIPTION
Pin `setuptools` to the maximum version of 70 to allow working on Ubuntu 20.04 LTS based environments. (New versions of `setuptools` are not compatible.)

Note that this fix is necessary only for the `maint-0.9` branches and the REANA 0.9 release series. In `master` we have switched to Ubuntu 24.04 LTS based environments and Python 3.12 and no pinning is necessary there.