### PR TITLE
feat(dask): detect and create VOMS_proxy resources for Dask cluster

### DIFF
--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -353,6 +353,14 @@ class WorkflowRunManager:
             .get("kerberos", False)
         )
 
+    def requires_voms_proxy(self) -> bool:
+        """Check whether Voms_proxy is necessary to run the workflow engine."""
+        return (
+            self.workflow.reana_specification["workflow"]
+            .get("resources", {})
+            .get("voms_proxy", False)
+        )
+
 
 class KubernetesWorkflowRunManager(WorkflowRunManager):
     """Implementation of WorkflowRunManager for Kubernetes."""
@@ -400,6 +408,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                         REANA_DASK_CLUSTER_DEFAULT_SINGLE_WORKER_MEMORY,
                     ),
                     kerberos=self.requires_kerberos(),
+                    voms_proxy=self.requires_voms_proxy(),
                 ).create_dask_resources()
 
             current_k8s_batchv1_api_client.create_namespaced_job(

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_requires = [
     "marshmallow>2.13.0,<3.0.0",  # same upper pin as reana-server
     "opensearch-py>=2.7.0,<2.8.0",
     "packaging>=18.0",
-    "reana-commons[kubernetes]>=0.95.0a7,<0.96.0",
+    "reana-commons[kubernetes]>=0.95.0a8,<0.96.0",
     "reana-db>=0.95.0a5,<0.96.0",
     "requests>=2.25.0",
     "sqlalchemy-utils>=0.31.0",


### PR DESCRIPTION
We detect if VOMS_proxy is necessary for Dask cluster by checking top level voms_proxy statement under resources field in reana.yaml. Some amendments were needed in order to fetch the secrets from secrets store instead of environment variables since workflow controller does not have access to runtime environment variables just like job controller.

Closes reanahub/reana#872