### PR TITLE
fix(config): update reana-auth-vomsproxy to 1.3.1 to fix WLCG IAM

### DIFF
--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -352,7 +352,7 @@ REANA_DASK_CLUSTER_DEFAULT_SINGLE_WORKER_THREADS = int(
 """Number of threads for one Dask worker by default."""
 
 VOMSPROXY_CONTAINER_IMAGE = os.getenv(
-    "VOMSPROXY_CONTAINER_IMAGE", "docker.io/reanahub/reana-auth-vomsproxy:1.3.0"
+    "VOMSPROXY_CONTAINER_IMAGE", "docker.io/reanahub/reana-auth-vomsproxy:1.3.1"
 )
 """Default docker image of VOMSPROXY sidecar container."""
 


### PR DESCRIPTION
Update reana-auth-vomsproxy to the latest version in order to fix VOMS proxy initialisation troubles for server-side VOMS authentication techniques.

Closes reanahub/reana-auth-vomsproxy#34