### PR TITLE
feat(config): introduce new parameters for uWSGI worker recyling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -73,13 +73,21 @@ ARG UWSGI_BUFFER_SIZE=8192
 ARG UWSGI_MAX_FD=1048576
 ARG UWSGI_PROCESSES=2
 ARG UWSGI_THREADS=2
+ARG UWSGI_IDLE=60
+ARG UWSGI_MAX_REQUESTS=1999
+ARG UWSGI_MAX_WORKER_LIFETIME=3600
+ARG UWSGI_RELOAD_ON_RSS=1024
 ENV FLASK_APP=reana_workflow_controller/app.py \
     PYTHONPATH=/workdir \
     TERM=xterm \
     UWSGI_BUFFER_SIZE=${UWSGI_BUFFER_SIZE:-8192} \
     UWSGI_MAX_FD=${UWSGI_MAX_FD:-1048576} \
     UWSGI_PROCESSES=${UWSGI_PROCESSES:-2} \
-    UWSGI_THREADS=${UWSGI_THREADS:-2}
+    UWSGI_THREADS=${UWSGI_THREADS:-2} \
+    UWSGI_IDLE=${UWSGI_IDLE:-60} \
+    UWSGI_MAX_REQUESTS=${UWSGI_MAX_REQUESTS:-1999} \
+    UWSGI_MAX_WORKER_LIFETIME=${UWSGI_MAX_WORKER_LIFETIME:-3600} \
+    UWSGI_RELOAD_ON_RSS=${UWSGI_RELOAD_ON_RSS:-1024}
 
 # Expose ports to clients
 EXPOSE 5000
@@ -104,11 +112,15 @@ CMD exec uwsgi \
     --stats /tmp/stats.socket \
     --threads ${UWSGI_THREADS} \
     --vacuum \
-    --wsgi-disable-file-wrapper
+    --wsgi-disable-file-wrapper \
+    --idle ${UWSGI_IDLE} \
+    --max-requests ${UWSGI_MAX_REQUESTS} \
+    --max-worker-lifetime ${UWSGI_MAX_WORKER_LIFETIME} \
+    --reload-on-rss ${UWSGI_RELOAD_ON_RSS}
 
 # Set image labels
 LABEL org.opencontainers.image.authors="team@reanahub.io"
-LABEL org.opencontainers.image.created="2024-11-29"
+LABEL org.opencontainers.image.created="2025-03-26"
 LABEL org.opencontainers.image.description="REANA reproducible analysis platform - workflow controller component"
 LABEL org.opencontainers.image.documentation="https://reana-workflow-controller.readthedocs.io/"
 LABEL org.opencontainers.image.licenses="MIT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ alembic==1.13.1           # via reana-db
 amqp==5.2.0               # via kombu
 appdirs==1.4.4            # via fs
 attrs==23.2.0             # via jsonschema
-backports-zoneinfo[tzdata]==0.2.1  # via backports-zoneinfo, kombu
+backports-zoneinfo[tzdata]==0.2.1  # via kombu
 bracex==2.4               # via wcmatch
 bravado==10.3.2           # via reana-commons
 bravado-core==6.1.0       # via bravado, reana-commons
@@ -25,8 +25,8 @@ gitdb==4.0.11             # via gitpython
 gitpython==3.1.42         # via reana-workflow-controller (setup.py)
 google-auth==2.28.1       # via kubernetes
 idna==2.10                # via jsonschema, requests
-importlib-metadata==7.0.1  # via alembic, flask
-importlib-resources==6.1.2  # via alembic
+importlib-metadata==8.5.0  # via alembic, flask
+importlib-resources==6.4.5  # via alembic
 itsdangerous==2.1.2       # via flask
 jinja2==3.1.3             # via flask
 jsonpickle==3.0.3         # via reana-workflow-controller (setup.py)
@@ -52,8 +52,8 @@ pyrsistent==0.20.0        # via jsonschema
 python-dateutil==2.9.0    # via bravado, bravado-core, kubernetes
 pytz==2024.1              # via bravado-core
 pyyaml==6.0.1             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.9.9	# via reana-db, reana-workflow-controller (setup.py)
-reana-db==0.9.5	# via reana-workflow-controller (setup.py)
+reana-commons[kubernetes]==0.9.9  # via reana-db, reana-workflow-controller (setup.py)
+reana-db==0.9.5           # via reana-workflow-controller (setup.py)
 requests==2.25.0          # via bravado, bravado-core, kubernetes, reana-workflow-controller (setup.py), requests-oauthlib
 requests-oauthlib==1.3.1  # via kubernetes
 rfc3987==1.3.8            # via jsonschema
@@ -66,18 +66,18 @@ sqlalchemy-utils[encrypted]==0.41.1  # via reana-db, reana-workflow-controller (
 strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==3.0.3  # via bravado-core
 typing-extensions==4.10.0  # via alembic, bravado, kombu, swagger-spec-validator
-tzdata==2024.1            # via backports-zoneinfo
+tzdata==2025.2            # via backports-zoneinfo
 urllib3==1.26.18          # via kubernetes, requests
-uwsgi==2.0.24             # via reana-workflow-controller (setup.py)
+uwsgi==2.0.28             # via reana-workflow-controller (setup.py)
 uwsgi-tools==1.1.1        # via reana-workflow-controller (setup.py)
-uwsgitop==0.11            # via reana-workflow-controller (setup.py)
+uwsgitop==0.12            # via reana-workflow-controller (setup.py)
 vine==5.1.0               # via amqp, kombu
 wcmatch==8.4.1            # via reana-commons
 webargs==6.1.1            # via reana-workflow-controller (setup.py)
 webcolors==1.13           # via jsonschema
 websocket-client==1.7.0   # via kubernetes
 werkzeug==2.3.8           # via flask, reana-commons, reana-workflow-controller (setup.py)
-zipp==3.17.0              # via importlib-metadata, importlib-resources
+zipp==3.20.2              # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2025 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -61,8 +61,8 @@ install_requires = [
     "requests==2.25.0",
     "sqlalchemy-utils>=0.31.0",
     "uwsgi-tools>=1.1.1",
-    "uWSGI>=2.0.17",
-    "uwsgitop>=0.10",
+    "uWSGI>=2.0.28",
+    "uwsgitop>=0.12",
     "webargs>=6.1.0,<7.0.0",
 ]
 


### PR DESCRIPTION
Upgrade `uwsgi` version and add new parameters for worker recycling.

- `idle`: Restarts the worker after it has been idle for the specified number of seconds.
- `max-requests`: Restarts the worker after serving the specified number of requests.
- `max-worker-lifetime`: Restarts the worker after running for the specified number of seconds.
- `reload-on-rss`: Restarts the worker when its resident memory exceeds the specified threshold.

Closes #641