### PR TITLE
feat(dask): return service logs and fix service status handling

### DIFF
--- a/reana_workflow_controller/consumer.py
+++ b/reana_workflow_controller/consumer.py
@@ -29,7 +29,6 @@ from reana_commons.utils import (
     calculate_hash_of_dir,
     calculate_job_input_hash,
     build_unique_component_name,
-    get_dask_component_name,
 )
 from reana_db.database import Session
 from reana_db.models import Job, JobCache, Workflow, RunStatus, Service

--- a/reana_workflow_controller/rest/utils.py
+++ b/reana_workflow_controller/rest/utils.py
@@ -60,12 +60,10 @@ from webargs.flaskparser import parser
 from werkzeug.exceptions import BadRequest, NotFound
 
 from reana_workflow_controller.config import (
-    DASK_ENABLED,
     PROGRESS_STATUSES,
     REANA_GITLAB_HOST,
     PREVIEWABLE_MIME_TYPE_PREFIXES,
 )
-from reana_workflow_controller.dask import requires_dask
 from reana_workflow_controller.consumer import _update_workflow_status
 from reana_workflow_controller.errors import (
     REANAExternalCallError,
@@ -185,52 +183,11 @@ def build_workflow_logs(workflow, steps=None, paginate=None):
 
         open_search_log_fetcher = build_opensearch_log_fetcher()
 
-        logs = None
-
-        if DASK_ENABLED and requires_dask(workflow):
-            logs = (
-                (open_search_log_fetcher.fetch_job_logs(job.backend_job_id) or "")
-                + """
-
-                -------------------------------------------------------------------
-                -------------------------------------------------------------------
-                ----------------        DASK SCHEDULER LOGS        ----------------
-                -------------------------------------------------------------------
-                -------------------------------------------------------------------
-
-
-
-                """
-                + (
-                    open_search_log_fetcher.fetch_dask_scheduler_logs(job.workflow_uuid)
-                    or ""
-                )
-                + """
-
-                -------------------------------------------------------------------
-                -------------------------------------------------------------------
-                ----------------         DASK WORKER LOGS          ----------------
-                -------------------------------------------------------------------
-                -------------------------------------------------------------------
-
-
-
-
-                """
-                + (
-                    open_search_log_fetcher.fetch_dask_worker_logs(job.workflow_uuid)
-                    or ""
-                )
-                if open_search_log_fetcher
-                else None
-            )
-
-        else:
-            logs = (
-                open_search_log_fetcher.fetch_job_logs(job.backend_job_id)
-                if open_search_log_fetcher
-                else None
-            )
+        logs = (
+            open_search_log_fetcher.fetch_job_logs(job.backend_job_id)
+            if open_search_log_fetcher
+            else None
+        )
 
         item = {
             "workflow_uuid": str(job.workflow_uuid) or "",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1234,6 +1234,7 @@ def test_get_created_workflow_logs(
                                 "finished_at": None,
                             }
                         },
+                        "service_logs": {},
                         "engine_specific": None,
                     }
                 ),
@@ -1280,7 +1281,7 @@ def test_get_created_workflow_opensearch_disabled(
                 "workflow_name": workflow_name,
                 "user": str(user0.id_),
                 "live_logs_enabled": False,
-                "logs": '{"workflow_logs": "", "job_logs": {},'
+                "logs": '{"workflow_logs": "", "job_logs": {}, "service_logs": {},'
                 ' "engine_specific": null}',
             }
             assert response_data == expected_data


### PR DESCRIPTION
- Mark the Dask service as deleted instead of removing it when the Dask cluster terminates.
- Return the service logs in the response