### PR TITLE
feat(manager): add Kueue scheduling option for user workloads

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,3 +25,4 @@ The list of contributors in alphabetical order:
 - [Sinclert Perez](https://www.linkedin.com/in/sinclert)
 - [Tibor Simko](https://orcid.org/0000-0001-7202-5803)
 - [Vladyslav Moisieienkov](https://orcid.org/0000-0001-9717-0775)
+- [Xavier Tintin](https://orcid.org/0000-0002-3150-9112)

--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -17,6 +17,7 @@ from reana_commons.config import (
     SHARED_VOLUME_PATH,
 )
 from reana_db.models import JobStatus, RunStatus
+from distutils.util import strtobool
 
 from reana_workflow_controller.version import __version__
 
@@ -393,6 +394,12 @@ ALIVE_STATUSES = [
     RunStatus.pending,
 ]
 """Alive workflow statuses."""
+
+KUEUE_ENABLED = bool(strtobool(os.getenv("KUEUE_ENABLED", "False")))
+"""Whether to use Kueue for workflow scheduling."""
+
+KUEUE_LOCAL_QUEUE_NAME = "local-queue-batch"
+"""Name of the local queue to be used by Kueue."""
 
 REANA_RUNTIME_BATCH_TERMINATION_GRACE_PERIOD = int(
     os.getenv("REANA_RUNTIME_BATCH_TERMINATION_GRACE_PERIOD", "120")


### PR DESCRIPTION
Introduces [Kueue](https://kueue.sigs.k8s.io/docs/overview/) as an alternative way to submit user jobs.

Kueue is disabled by default.

See [related reana PR](https://github.com/reanahub/reana/pull/903) for testing instructions.

Closes https://github.com/reanahub/reana/issues/800