### PR TITLE
feat: add workflow-uuid label to batch, dask, and session pods

### DIFF
--- a/reana_workflow_controller/dask.py
+++ b/reana_workflow_controller/dask.py
@@ -162,6 +162,7 @@ class DaskResourceManager:
             "labels": {
                 "user-uuid": self.user_id,
                 "reana-run-dask-workflow-uuid": self.workflow_id,
+                "workflow-uuid": self.workflow_id,
             },
         }
 
@@ -235,6 +236,7 @@ class DaskResourceManager:
             "labels": {
                 "user-uuid": self.user_id,
                 "reana-run-dask-workflow-uuid": self.workflow_id,
+                "workflow-uuid": self.workflow_id,
             },
         }
 
@@ -708,6 +710,7 @@ def create_dask_dashboard_ingress(workflow_id, user_id):
             "labels": {
                 "user-uuid": user_id,
                 "reana-run-dask-workflow-uuid": workflow_id,
+                "workflow-uuid": workflow_id,
             },
             "namespace": REANA_RUNTIME_KUBERNETES_NAMESPACE,
         },
@@ -731,6 +734,7 @@ def create_dask_dashboard_ingress(workflow_id, user_id):
             labels={
                 "user-uuid": user_id,
                 "reana-run-dask-workflow-uuid": workflow_id,
+                "workflow-uuid": workflow_id,
             },
         ),
         spec=client.V1IngressSpec(

--- a/reana_workflow_controller/k8s.py
+++ b/reana_workflow_controller/k8s.py
@@ -170,6 +170,7 @@ class InteractiveDeploymentK8sBuilder(object):
             "app": self.deployment_name,
             "reana_workflow_mode": "session",
             "reana-run-session-workflow-uuid": str(self.workflow_id),
+            "workflow-uuid": str(self.workflow_id),
             "user-uuid": str(self.owner_id),
         }
         template = client.V1PodTemplateSpec(

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -634,6 +634,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         labels = {
             "reana_workflow_mode": "batch",
             "reana-run-batch-workflow-uuid": str(self.workflow.id_),
+            "workflow-uuid": str(self.workflow.id_),
             "user-uuid": owner_id,
         }
 


### PR DESCRIPTION
This PR harmonises the metadata labeling by adding the `workflow-uuid` label to all runtime workloads produced by the Workflow Controller.


Closes reanahub/reana-workflow-controller#667


This change is part of a cross-repository update. Please merge in conjunction with:
- reanahub/reana-job-controller#498
- reanahub/reana-server#755