### PR TITLE
build(python): pin setuptools below 81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<81' py
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
@@ -223,7 +223,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<81' py
           pip install twine wheel
           pip install -e .[all]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update -y && \
       python3.12 \
       python3.12-dev \
       vim-tiny && \
-    pip install --no-cache-dir --upgrade setuptools && \
+    pip install --no-cache-dir --upgrade 'setuptools<81' && \
     pip install --no-cache-dir -r /code/requirements.txt && \
     apt-get remove -y \
       gcc \

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,5 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+setuptools<81
 -e .[all]

--- a/reana_workflow_controller/dask.py
+++ b/reana_workflow_controller/dask.py
@@ -5,6 +5,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Dask resource manager."""
+
 import logging
 import os
 import yaml

--- a/reana_workflow_controller/rest/workflows_session.py
+++ b/reana_workflow_controller/rest/workflows_session.py
@@ -8,7 +8,6 @@
 
 """REANA Workflow Controller interactive sessions REST API."""
 
-
 from flask import Blueprint, jsonify, request
 from webargs import fields
 from webargs.flaskparser import use_kwargs
@@ -17,7 +16,6 @@ from reana_db.utils import _get_workflow_with_uuid_or_name
 from reana_db.models import WorkflowSession, InteractiveSessionType, RunStatus
 
 from reana_workflow_controller.workflow_run_manager import KubernetesWorkflowRunManager
-
 
 blueprint = Blueprint("workflows_session", __name__)
 

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -5,6 +5,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Workflow run manager interface."""
+
 import base64
 import copy
 import json

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -119,7 +119,7 @@ def test_delete_workflow_with_interactive_session(
         "reana_workflow_controller.k8s",
         current_k8s_networking_api_client=mock.DEFAULT,
     ):
-        (response, http_response) = delete_workflow(workflow)
+        response, http_response = delete_workflow(workflow)
         data = json.loads(response.get_data())
         assert "Workflow successfully deleted" in data["message"]
         assert http_response == 200


### PR DESCRIPTION
Pin setuptools<81 in Dockerfile, CI workflows, and
ReadTheDocs configuration. This is because the recent
setuptools 81.0.0 upgrade removed the pkg_resources
module that is needed at runtime by some dependencies.