### PR TITLE
fix(dask): catch cleanup errors on cluster creation failures

### DIFF
--- a/reana_workflow_controller/dask.py
+++ b/reana_workflow_controller/dask.py
@@ -147,7 +147,12 @@ class DaskResourceManager:
             logging.error(
                 f"An error occured while trying to create dask cluster, now deleting the cluster... Error message:\n{e}"
             )
-            delete_dask_cluster(self.workflow_id, self.user_id)
+            try:
+                delete_dask_cluster(self.workflow_id, self.user_id)
+            except Exception:
+                logging.exception(
+                    "Failed to clean up Dask resources after creation error."
+                )
 
     def _prepare_cluster(self):
         """Prepare Dask cluster body by adding necessary image-pull secrets, volumes, volume mounts, init containers and sidecar containers."""

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -153,6 +153,23 @@ def test_add_hostpath_volumes_with_mounts(
         )
 
 
+def test_create_dask_resources_cleanup_error_is_swallowed(dask_resource_manager):
+    """Test that cleanup errors after creation failure do not propagate."""
+    with patch.object(
+        dask_resource_manager,
+        "_prepare_cluster",
+    ), patch.object(
+        dask_resource_manager,
+        "_create_dask_cluster",
+        side_effect=Exception("CRD not found"),
+    ), patch(
+        "reana_workflow_controller.dask.delete_dask_cluster",
+        side_effect=RuntimeError("cleanup failed"),
+    ):
+        # Should not raise despite both creation and cleanup failing
+        dask_resource_manager.create_dask_resources()
+
+
 def test_create_dask_resources(dask_resource_manager):
     """Test create_dask_resources method."""
     # Patch internal methods that should be called


### PR DESCRIPTION
When the creation of Dask Kubernetes resources fails, the cleanup call to delete_dask_cluster() could itself raise RuntimeError. (E.g. when CRDs are not installed.) The error then propagated beyond ApiException and surfaced as a 500 Internal Server Error, instead of providing a meaningful error message. This commit fixes the problem.