### PR TITLE
fix(dask): fix pulling from private container registries

### DIFF
--- a/reana_workflow_controller/dask.py
+++ b/reana_workflow_controller/dask.py
@@ -251,17 +251,17 @@ class DaskResourceManager:
         self.autoscaler_body["spec"]["maximum"] = self.num_of_workers
 
     def _add_image_pull_secrets(self):
-        """Attach the configured image pull secrets to scheduler and worker containers."""
+        """Attach the configured image pull secrets to scheduler and worker pods."""
         image_pull_secrets = []
         for secret_name in current_app.config["IMAGE_PULL_SECRETS"]:
             if secret_name:
                 image_pull_secrets.append({"name": secret_name})
 
-        self.cluster_body["spec"]["worker"]["spec"]["containers"][0][
+        self.cluster_body["spec"]["worker"]["spec"][
             "imagePullSecrets"
         ] = image_pull_secrets
 
-        self.cluster_body["spec"]["scheduler"]["spec"]["containers"][0][
+        self.cluster_body["spec"]["scheduler"]["spec"][
             "imagePullSecrets"
         ] = image_pull_secrets
 

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -85,15 +85,15 @@ def test_add_image_pull_secrets(dask_resource_manager):
         # Assert
         expected_image_pull_secrets = [{"name": "my-secret"}]
         assert (
-            dask_resource_manager.cluster_body["spec"]["worker"]["spec"]["containers"][
-                0
-            ]["imagePullSecrets"]
+            dask_resource_manager.cluster_body["spec"]["worker"]["spec"][
+                "imagePullSecrets"
+            ]
             == expected_image_pull_secrets
         )
         assert (
             dask_resource_manager.cluster_body["spec"]["scheduler"]["spec"][
-                "containers"
-            ][0]["imagePullSecrets"]
+                "imagePullSecrets"
+            ]
             == expected_image_pull_secrets
         )
 


### PR DESCRIPTION
The imagePullSecrets field for Dask workloads was set on the container level, which had no effect, and was leading Dask worker and scheduler pods to silently fail when pulling images from private registries. This commit fixes the problem by moving imagePullSecrets to the appropriate pod level in the specifications.