### PR TITLE
build(python): upgrade to Flask 3.x

### DIFF
--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -227,7 +227,7 @@ DEBUG_ENV_VARS = (
         "value": os.getenv("WDB_SOCKET_SERVER", f"{REANA_COMPONENT_PREFIX}-wdb"),
     },
     {"name": "WDB_NO_BROWSER_AUTO_OPEN", "value": "True"},
-    {"name": "FLASK_ENV", "value": "development"},
+    {"name": "FLASK_DEBUG", "value": "1"},
 )
 """Common to all workflow engines environment variables for debug mode."""
 

--- a/reana_workflow_controller/rest/utils.py
+++ b/reana_workflow_controller/rest/utils.py
@@ -266,10 +266,14 @@ def delete_workflow(workflow, all_runs=False, workspace=False):
                     remove_workflow_workspace(workflow.workspace_path)
                     # 3. update the disk usage of the user
                     disk_resource = get_default_quota_resource(ResourceType.disk.name)
-                    workflow_disk_resource = WorkflowResource.query.filter(
-                        WorkflowResource.workflow_id == workflow.id_,
-                        WorkflowResource.resource_id == disk_resource.id_,
-                    ).one_or_none()
+                    workflow_disk_resource = (
+                        Session.query(WorkflowResource)
+                        .filter(
+                            WorkflowResource.workflow_id == workflow.id_,
+                            WorkflowResource.resource_id == disk_resource.id_,
+                        )
+                        .one_or_none()
+                    )
                     disk_usage = None
                     if workflow_disk_resource:
                         disk_usage = workflow_disk_resource.quota_used

--- a/reana_workflow_controller/rest/workflows.py
+++ b/reana_workflow_controller/rest/workflows.py
@@ -19,6 +19,7 @@ from flask import Blueprint, jsonify, request
 from sqlalchemy import and_, nullslast, or_, select
 from sqlalchemy.orm import aliased
 from sqlalchemy.exc import IntegrityError
+import marshmallow
 from webargs import fields, validate
 from webargs.flaskparser import use_args, use_kwargs
 from reana_commons.config import WORKFLOW_TIME_FORMAT
@@ -80,18 +81,19 @@ blueprint = Blueprint("workflows", __name__)
     {
         "include_progress": fields.Bool(),
         "include_workspace_size": fields.Bool(),
-        "search": fields.String(missing=""),
-        "sort": fields.String(missing="desc"),
-        "status": fields.String(missing=""),
+        "search": fields.String(load_default=""),
+        "sort": fields.String(load_default="desc"),
+        "status": fields.String(load_default=""),
         "type": fields.String(required=True),
         "user": fields.String(required=True),
-        "verbose": fields.Bool(missing=False),
+        "verbose": fields.Bool(load_default=False),
         "workflow_id_or_name": fields.String(),
-        "shared": fields.Bool(missing=False),
+        "shared": fields.Bool(load_default=False),
         "shared_by": fields.String(),
         "shared_with": fields.String(),
     },
     location="query",
+    unknown=marshmallow.EXCLUDE,
 )
 def get_workflows(args, paginate=None):  # noqa
     r"""Get all workflows.
@@ -318,7 +320,7 @@ def get_workflows(args, paginate=None):  # noqa
 
     try:
 
-        user = User.query.filter(User.id_ == user_uuid).first()
+        user = Session.query(User).filter(User.id_ == user_uuid).first()
         if not user:
             return jsonify({"message": "User {} does not exist".format(user_uuid)}), 404
 
@@ -590,7 +592,7 @@ def create_workflow():  # noqa
     """
     try:
         user_uuid = request.args["user"]
-        user = User.query.filter(User.id_ == user_uuid).first()
+        user = Session.query(User).filter(User.id_ == user_uuid).first()
         if not user:
             return (
                 jsonify(
@@ -946,7 +948,9 @@ def get_workflow_diff(workflow_id_or_name_a, workflow_id_or_name_b):  # noqa
 
 
 @blueprint.route("/workflows/<workflow_id_or_name>/retention_rules")
-@use_kwargs({"user": fields.Str(required=True)}, location="query")
+@use_kwargs(
+    {"user": fields.Str(required=True)}, location="query", unknown=marshmallow.EXCLUDE
+)
 def get_workflow_retention_rules(workflow_id_or_name: str, user: str):
     r"""Get the retention rules of a workflow.
 
@@ -1058,7 +1062,9 @@ def get_workflow_retention_rules(workflow_id_or_name: str, user: str):
 
 
 @blueprint.route("/workflows/<workflow_id_or_name>/share", methods=["POST"])
-@use_kwargs({"user": fields.Str(required=True)}, location="query")
+@use_kwargs(
+    {"user": fields.Str(required=True)}, location="query", unknown=marshmallow.EXCLUDE
+)
 @use_kwargs(
     {
         "user_email_to_share_with": fields.Str(required=True),
@@ -1170,7 +1176,7 @@ def share_workflow(
     valid_until = kwargs.get("valid_until")
 
     try:
-        sharer = User.query.filter(User.id_ == user).first()
+        sharer = Session.query(User).filter(User.id_ == user).first()
         if not sharer:
             return (
                 jsonify({"message": f"User with id '{user}' does not exist."}),
@@ -1243,6 +1249,7 @@ def share_workflow(
         "user_email_to_unshare_with": fields.Str(required=True),
     },
     location="query",
+    unknown=marshmallow.EXCLUDE,
 )
 def unshare_workflow(
     workflow_id_or_name: str, user: str, user_email_to_unshare_with: str
@@ -1362,7 +1369,7 @@ def unshare_workflow(
               }
     """
     try:
-        sharer = User.query.filter(User.id_ == user).first()
+        sharer = Session.query(User).filter(User.id_ == user).first()
         if not sharer:
             return (
                 jsonify({"message": f"User with id '{sharer}' does not exist."}),
@@ -1411,7 +1418,9 @@ def unshare_workflow(
 
 
 @blueprint.route("/workflows/<workflow_id_or_name>/share-status", methods=["GET"])
-@use_kwargs({"user": fields.Str(required=True)}, location="query")
+@use_kwargs(
+    {"user": fields.Str(required=True)}, location="query", unknown=marshmallow.EXCLUDE
+)
 def get_workflow_share_status(
     workflow_id_or_name: str,
     user: str,

--- a/reana_workflow_controller/rest/workflows_session.py
+++ b/reana_workflow_controller/rest/workflows_session.py
@@ -8,6 +8,7 @@
 
 """REANA Workflow Controller interactive sessions REST API."""
 
+import marshmallow
 from flask import Blueprint, jsonify, request
 from webargs import fields
 from webargs.flaskparser import use_kwargs
@@ -24,7 +25,9 @@ blueprint = Blueprint("workflows_session", __name__)
     "/workflows/<workflow_id_or_name>/open/<interactive_session_type>",
     methods=["POST"],
 )
-@use_kwargs({"user": fields.Str(required=True)}, location="query")
+@use_kwargs(
+    {"user": fields.Str(required=True)}, location="query", unknown=marshmallow.EXCLUDE
+)
 @use_kwargs({"image": fields.Str()}, location="json")
 def open_interactive_session(
     workflow_id_or_name, interactive_session_type, user, **kwargs

--- a/reana_workflow_controller/rest/workflows_status.py
+++ b/reana_workflow_controller/rest/workflows_status.py
@@ -11,6 +11,7 @@
 import json
 
 from flask import Blueprint, jsonify, request
+import marshmallow
 from webargs import fields
 from webargs.flaskparser import use_kwargs
 
@@ -362,6 +363,7 @@ def get_workflow_status(workflow_id_or_name):  # noqa
         "status": fields.Str(required=True),
     },
     location="query",
+    unknown=marshmallow.EXCLUDE,
 )
 def set_workflow_status(
     workflow_id_or_name: str, user: str, status: str, **parameters: dict

--- a/reana_workflow_controller/rest/workflows_workspace.py
+++ b/reana_workflow_controller/rest/workflows_workspace.py
@@ -24,6 +24,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from reana_commons import workspace
 from reana_commons.errors import REANAWorkspaceError
+from reana_db.database import Session
 from reana_db.models import User
 from reana_db.utils import (
     _get_workflow_with_uuid_or_name,
@@ -248,7 +249,7 @@ def download_file(workflow_id_or_name, file_name):  # noqa
     """
     try:
         user_uuid = request.args["user"]
-        user = User.query.filter(User.id_ == user_uuid).first()
+        user = Session.query(User).filter(User.id_ == user_uuid).first()
         if not user:
             return jsonify({"message": "User {} does not exist".format(user)}), 404
 
@@ -337,7 +338,7 @@ def delete_file(workflow_id_or_name, file_name):  # noqa
     """
     try:
         user_uuid = request.args["user"]
-        user = User.query.filter(User.id_ == user_uuid).first()
+        user = Session.query(User).filter(User.id_ == user_uuid).first()
         if not user:
             return jsonify({"message": "User {} does not exist".format(user)}), 404
 
@@ -471,7 +472,7 @@ def get_files(workflow_id_or_name, paginate=None):  # noqa
     try:
         user_uuid = request.args["user"]
         search = request.args.get("search")
-        user = User.query.filter(User.id_ == user_uuid).first()
+        user = Session.query(User).filter(User.id_ == user_uuid).first()
         if not user:
             return jsonify({"message": "User {} does not exist".format(user)}), 404
 

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -167,7 +167,7 @@ def _validate_interactive_session_image(type_: str, user_image: Optional[str]) -
 class WorkflowRunManager:
     """Interface which specifies how to manage workflow runs."""
 
-    if os.getenv("FLASK_ENV") == "development":
+    if os.getenv("FLASK_DEBUG", "").lower() in ("1", "true"):
         WORKFLOW_ENGINE_COMMON_ENV_VARS.extend(DEBUG_ENV_VARS)
 
     engine_mapping = {
@@ -533,9 +533,11 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
 
     def stop_interactive_session(self, interactive_session_id):
         """Stop an interactive workflow run."""
-        int_session = InteractiveSession.query.filter_by(
-            id_=interactive_session_id
-        ).first()
+        int_session = (
+            Session.query(InteractiveSession)
+            .filter_by(id_=interactive_session_id)
+            .first()
+        )
 
         if not int_session:
             raise REANAInteractiveSessionError(
@@ -867,7 +869,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         # filter out volumes with the same name
         spec.template.spec.volumes = list({v["name"]: v for v in volumes}.values())
 
-        if os.getenv("FLASK_ENV") == "development":
+        if os.getenv("FLASK_DEBUG", "").lower() in ("1", "true"):
             code_volume_name = "reana-code"
             code_mount_path = "/code"
             k8s_code_volume = client.V1Volume(name=code_volume_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,26 +9,27 @@ amqp==5.3.1               # via kombu
 appdirs==1.4.4            # via fs
 arrow==1.4.0              # via isoduration
 attrs==26.1.0             # via jsonschema, referencing
+blinker==1.9.0            # via flask
 bracex==2.6               # via wcmatch
 bravado==10.3.2           # via reana-commons
 bravado-core==6.1.0       # via bravado, reana-commons
-certifi==2026.2.25        # via kubernetes, opensearch-py, requests
+certifi==2026.4.22        # via kubernetes, opensearch-py, requests
 cffi==2.0.0               # via cryptography
-charset-normalizer==3.4.6  # via requests
+charset-normalizer==3.4.7  # via requests
 checksumdir==1.1.9        # via reana-commons
-click==8.3.1              # via flask, reana-commons
-cryptography==46.0.6      # via google-auth, sqlalchemy-utils
+click==8.3.3              # via flask, reana-commons
+cryptography==47.0.0      # via sqlalchemy-utils
+durationpy==0.10          # via kubernetes
 events==0.5               # via opensearch-py
-flask==2.2.5              # via reana-workflow-controller (setup.py)
+flask==3.1.3              # via reana-workflow-controller (setup.py)
 fqdn==1.5.1               # via jsonschema
 fs==2.4.16                # via reana-commons
 gherkin-official==39.0.0  # via reana-commons
 gitdb==4.0.12             # via gitpython
-gitpython==3.1.46         # via reana-workflow-controller (setup.py)
-google-auth==2.49.1       # via kubernetes
-greenlet==3.3.2           # via sqlalchemy
-idna==3.11                # via jsonschema, requests
-importlib-resources==6.5.2  # via swagger-spec-validator
+gitpython==3.1.48         # via reana-workflow-controller (setup.py)
+greenlet==3.5.0           # via sqlalchemy
+idna==3.13                # via jsonschema, requests
+importlib-resources==7.1.0  # via swagger-spec-validator
 isoduration==20.11.0      # via jsonschema
 itsdangerous==2.2.0       # via flask
 jinja2==3.1.6             # via flask
@@ -38,52 +39,50 @@ jsonref==1.1.0            # via bravado-core
 jsonschema[format]==4.26.0  # via bravado-core, reana-commons, swagger-spec-validator
 jsonschema-specifications==2025.9.1  # via jsonschema
 kombu==5.6.2              # via reana-commons
-kubernetes==26.1.0        # via reana-commons
-mako==1.3.10              # via alembic
-markupsafe==3.0.3         # via jinja2, mako, werkzeug
-marshmallow==2.21.0       # via reana-workflow-controller (setup.py), webargs
+kubernetes==35.0.0        # via reana-commons
+mako==1.3.11              # via alembic
+markupsafe==3.0.3         # via flask, jinja2, mako, werkzeug
+marshmallow==3.26.2       # via reana-workflow-controller (setup.py), webargs
 mock==3.0.5               # via reana-commons
 monotonic==1.6            # via bravado
 msgpack==1.1.2            # via bravado-core
 msgpack-python==0.5.6     # via bravado
 oauthlib==3.3.1           # via requests-oauthlib
 opensearch-py==2.7.1      # via reana-workflow-controller (setup.py)
-packaging==26.0           # via kombu, reana-workflow-controller (setup.py)
+packaging==26.2           # via kombu, marshmallow, reana-workflow-controller (setup.py), webargs
 parse==1.21.1             # via reana-commons
-psycopg2-binary==2.9.11   # via reana-db
-pyasn1==0.6.3             # via pyasn1-modules
-pyasn1-modules==0.4.2     # via google-auth
+psycopg2-binary==2.9.12   # via reana-db
 pycparser==3.0            # via cffi
 python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, kubernetes, opensearch-py
 pytz==2026.1.post1        # via bravado-core
 pyuwsgi==2.0.30.post1     # via reana-workflow-controller (setup.py)
 pyyaml==6.0.3             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.95.0a14  # via reana-db, reana-workflow-controller (setup.py)
-reana-db==0.95.0a6        # via reana-workflow-controller (setup.py)
+reana-commons[kubernetes]==0.95.0a15  # via reana-db, reana-workflow-controller (setup.py)
+reana-db==0.95.0a7        # via reana-workflow-controller (setup.py)
 referencing==0.37.0       # via jsonschema, jsonschema-specifications
-requests==2.33.0          # via bravado, bravado-core, kubernetes, opensearch-py, reana-workflow-controller (setup.py), requests-oauthlib
+requests==2.33.1          # via bravado, bravado-core, kubernetes, opensearch-py, reana-workflow-controller (setup.py), requests-oauthlib
 requests-oauthlib==2.0.0  # via kubernetes
 rfc3339-validator==0.1.4  # via jsonschema
 rfc3987==1.3.8            # via jsonschema
 rpds-py==0.30.0           # via jsonschema, referencing
-simplejson==3.20.2        # via bravado, bravado-core
+simplejson==4.1.1         # via bravado, bravado-core
 six==1.17.0               # via bravado, bravado-core, fs, kubernetes, mock, python-dateutil, rfc3339-validator
 smmap==5.0.3              # via gitdb
-sqlalchemy==1.4.54        # via alembic, reana-db, sqlalchemy-utils
-sqlalchemy-utils[encrypted]==0.42.1  # via reana-db, reana-workflow-controller (setup.py)
+sqlalchemy==2.0.49        # via alembic, reana-db, sqlalchemy-utils
+sqlalchemy-utils[encrypted]==0.41.2  # via reana-db, reana-workflow-controller (setup.py)
 swagger-spec-validator==3.0.4  # via bravado-core
-typing-extensions==4.15.0  # via alembic, bravado, gherkin-official, referencing, swagger-spec-validator
-tzdata==2025.3            # via arrow, kombu
+typing-extensions==4.15.0  # via alembic, bravado, gherkin-official, referencing, sqlalchemy, swagger-spec-validator
+tzdata==2026.2            # via arrow, kombu
 uri-template==1.3.0       # via jsonschema
 urllib3==2.6.3            # via kubernetes, opensearch-py, requests
 uwsgi-tools==1.1.1        # via reana-workflow-controller (setup.py)
 uwsgitop==0.12            # via reana-workflow-controller (setup.py)
 vine==5.1.0               # via amqp, kombu
 wcmatch==8.4.1            # via reana-commons
-webargs==6.1.1            # via reana-workflow-controller (setup.py)
+webargs==8.7.1            # via reana-workflow-controller (setup.py)
 webcolors==25.10.0        # via jsonschema
 websocket-client==1.9.0   # via kubernetes
-werkzeug==2.2.3           # via flask, reana-commons, reana-workflow-controller (setup.py)
+werkzeug==3.1.8           # via flask, reana-commons, reana-workflow-controller (setup.py)
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -32,7 +32,7 @@ clean_old_db_container() {
     OLD="$(docker ps --all --quiet --filter=name=postgres__reana-workflow-controller)"
     if [ -n "$OLD" ]; then
         echo '==> [INFO] Cleaning old DB container...'
-        docker stop postgres__reana-workflow-controller
+        docker rm -f postgres__reana-workflow-controller >/dev/null 2>&1 || true
     fi
 }
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extras_require = {
         "sphinxcontrib-redoc>=1.5.1",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a4,<0.96.0",
+        "pytest-reana>=0.95.0a9,<0.96.0",
     ],
 }
 
@@ -44,21 +44,21 @@ for key, reqs in extras_require.items():
     extras_require["all"].extend(reqs)
 
 install_requires = [
-    "Flask>=2.1.1,<2.3.0",  # same upper pin as invenio-base/reana-server
-    "Werkzeug>=2.1.0,<2.3.0",  # same upper pin as invenio-base
+    "Flask>=3.0.0,<4.0.0",
+    "Werkzeug>=3.0.0",
     "gitpython>=2.1",
     "jsonpickle>=0.9.6",
-    "marshmallow>2.13.0,<3.0.0",  # same upper pin as reana-server
+    "marshmallow>=3.5.0,<4.0.0",
     "opensearch-py>=2.7.0,<2.8.0",
     "packaging>=18.0",
-    "reana-commons[kubernetes]>=0.95.0a14,<0.96.0",
-    "reana-db>=0.95.0a6,<0.96.0",
+    "reana-commons[kubernetes]>=0.95.0a15,<0.96.0",
+    "reana-db>=0.95.0a7,<0.96.0",
     "requests>=2.25.0",
     "sqlalchemy-utils>=0.31.0",
     "uwsgi-tools>=1.1.1",
     "pyuwsgi>=2.0.17",
     "uwsgitop>=0.10",
-    "webargs>=6.1.0,<7.0.0",
+    "webargs>=8.0",
 ]
 
 packages = find_packages()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def base_app(tmp_shared_volume_path):
         "SHARED_VOLUME_PATH": tmp_shared_volume_path,
         "SQLALCHEMY_DATABASE_URI": os.getenv("REANA_SQLALCHEMY_DATABASE_URI"),
         "SQLALCHEMY_TRACK_MODIFICATIONS": False,
-        "FLASK_ENV": "development",
+        "DEBUG": True,
         "ORGANIZATIONS": ["default"],
     }
     app_ = create_app(config_mapping=config_mapping)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,7 @@ from typing import ContextManager
 
 import mock
 import pytest
+from reana_db.database import Session
 from reana_db.models import (
     InteractiveSession,
     InteractiveSessionType,
@@ -197,7 +198,9 @@ def test_workspace_deletion(
 
     # check that all cache entries for jobs
     # of the deleted workflow are removed
-    cache_entries_after_delete = JobCache.query.filter_by(job_id=workflow_job.id_).all()
+    cache_entries_after_delete = (
+        Session.query(JobCache).filter_by(job_id=workflow_job.id_).all()
+    )
     assert not cache_entries_after_delete
     assert not os.path.exists(cache_dir_path)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,6 +17,7 @@ import fs
 import mock
 import pytest
 from flask import url_for
+from reana_db.database import Session
 from reana_db.models import (
     InteractiveSession,
     Job,
@@ -301,16 +302,18 @@ def test_create_workflow_with_name(
         assert res.status_code == 201
         response_data = json.loads(res.get_data(as_text=True))
         # Check workflow fetch by id
-        workflow_by_id = Workflow.query.filter(
-            Workflow.id_ == response_data.get("workflow_id")
-        ).first()
+        workflow_by_id = (
+            Session.query(Workflow)
+            .filter(Workflow.id_ == response_data.get("workflow_id"))
+            .first()
+        )
         assert workflow_by_id
 
         # Check workflow fetch by name and that name of created workflow
         # is the same that was supplied to `api.create_workflow`
-        workflow_by_name = Workflow.query.filter(
-            Workflow.name == "my_test_workflow"
-        ).first()
+        workflow_by_name = (
+            Session.query(Workflow).filter(Workflow.name == "my_test_workflow").first()
+        )
         assert workflow_by_name
 
         workflow = workflow_by_id
@@ -338,9 +341,11 @@ def test_create_workflow_without_name(
         response_data = json.loads(res.get_data(as_text=True))
 
         # Check workflow fetch by id
-        workflow_by_id = Workflow.query.filter(
-            Workflow.id_ == response_data.get("workflow_id")
-        ).first()
+        workflow_by_id = (
+            Session.query(Workflow)
+            .filter(Workflow.id_ == response_data.get("workflow_id"))
+            .first()
+        )
         assert workflow_by_id
 
         # Check workflow fetch by name and that name of created workflow
@@ -352,9 +357,11 @@ def test_create_workflow_without_name(
             reana_workflow_controller.config.DEFAULT_NAME_FOR_WORKFLOWS
         )
 
-        workflow_by_name = Workflow.query.filter(
-            Workflow.name == default_workflow_name
-        ).first()
+        workflow_by_name = (
+            Session.query(Workflow)
+            .filter(Workflow.name == default_workflow_name)
+            .first()
+        )
         assert workflow_by_name
 
         workflow = workflow_by_id
@@ -381,9 +388,11 @@ def test_create_workflow_wrong_user(
 
         assert res.status_code == 404
         response_data = json.loads(res.get_data(as_text=True))
-        workflow = Workflow.query.filter(
-            Workflow.id_ == response_data.get("workflow_id")
-        ).first()
+        workflow = (
+            Session.query(Workflow)
+            .filter(Workflow.id_ == response_data.get("workflow_id"))
+            .first()
+        )
         # workflow exists in DB
         assert not workflow
 
@@ -447,7 +456,7 @@ def test_download_file(
 
         response_data = json.loads(res.get_data(as_text=True))
         workflow_uuid = response_data.get("workflow_id")
-        workflow = Workflow.query.filter(Workflow.id_ == workflow_uuid).first()
+        workflow = Session.query(Workflow).filter(Workflow.id_ == workflow_uuid).first()
         # create file
         file_name = "output name.csv"
         file_binary_content = b"1,2,3,4\n5,6,7,8"
@@ -492,7 +501,7 @@ def test_download_file_with_path(
 
         response_data = json.loads(res.get_data(as_text=True))
         workflow_uuid = response_data.get("workflow_id")
-        workflow = Workflow.query.filter(Workflow.id_ == workflow_uuid).first()
+        workflow = Session.query(Workflow).filter(Workflow.id_ == workflow_uuid).first()
         # create file
         file_name = "first/1991/output.csv"
         file_binary_content = b"1,2,3,4\n5,6,7,8"
@@ -549,7 +558,7 @@ def test_download_dir_or_wildcard(
 
         response_data = json.loads(res.get_data(as_text=True))
         workflow_uuid = response_data.get("workflow_id")
-        workflow = Workflow.query.filter(Workflow.id_ == workflow_uuid).first()
+        workflow = Session.query(Workflow).filter(Workflow.id_ == workflow_uuid).first()
         # create files
         files = {
             "foo/1.txt": b"txt in foo dir",
@@ -609,7 +618,7 @@ def test_get_files(app, session, user0, tmp_shared_volume_path, cwl_workflow_wit
 
         response_data = json.loads(res.get_data(as_text=True))
         workflow_uuid = response_data.get("workflow_id")
-        workflow = Workflow.query.filter(Workflow.id_ == workflow_uuid).first()
+        workflow = Session.query(Workflow).filter(Workflow.id_ == workflow_uuid).first()
         # create file
         absolute_path_workflow_workspace = workflow.workspace_path
         fs_ = fs.open_fs(absolute_path_workflow_workspace)
@@ -663,7 +672,7 @@ def test_get_files_deleted_workflow(
         )
         assert res.status_code == 200
 
-        workflow = Workflow.query.filter(Workflow.id_ == workflow_uuid).first()
+        workflow = Session.query(Workflow).filter(Workflow.id_ == workflow_uuid).first()
         assert workflow.status == RunStatus.deleted
         assert not os.path.exists(workflow.workspace_path)
 
@@ -716,7 +725,7 @@ def test_get_workflow_status_with_uuid(
 
         response_data = json.loads(res.get_data(as_text=True))
         workflow_uuid = response_data.get("workflow_id")
-        workflow = Workflow.query.filter(Workflow.id_ == workflow_uuid).first()
+        workflow = Session.query(Workflow).filter(Workflow.id_ == workflow_uuid).first()
 
         res = client.get(
             url_for("statuses.get_workflow_status", workflow_id_or_name=workflow_uuid),
@@ -757,7 +766,9 @@ def test_get_workflow_status_with_name(app, session, user0, cwl_workflow_with_na
         session.add(workflow)
         session.commit()
 
-        workflow = Workflow.query.filter(Workflow.name == workflow_name).first()
+        workflow = (
+            Session.query(Workflow).filter(Workflow.name == workflow_name).first()
+        )
 
         res = client.get(
             url_for(
@@ -862,7 +873,11 @@ def test_set_workflow_status(
 
         response_data = json.loads(res.get_data(as_text=True))
         workflow_created_uuid = response_data.get("workflow_id")
-        workflow = Workflow.query.filter(Workflow.id_ == workflow_created_uuid).first()
+        workflow = (
+            Session.query(Workflow)
+            .filter(Workflow.id_ == workflow_created_uuid)
+            .first()
+        )
         assert workflow.status == RunStatus.created
         payload = START
         with mock.patch(
@@ -912,7 +927,11 @@ def test_start_already_started_workflow(
 
         response_data = json.loads(res.get_data(as_text=True))
         workflow_created_uuid = response_data.get("workflow_id")
-        workflow = Workflow.query.filter(Workflow.id_ == workflow_created_uuid).first()
+        workflow = (
+            Session.query(Workflow)
+            .filter(Workflow.id_ == workflow_created_uuid)
+            .first()
+        )
         assert workflow.status == RunStatus.created
         payload = START
         with mock.patch(
@@ -1077,7 +1096,7 @@ def test_upload_file(
 
         response_data = json.loads(res.get_data(as_text=True))
         workflow_uuid = response_data.get("workflow_id")
-        workflow = Workflow.query.filter(Workflow.id_ == workflow_uuid).first()
+        workflow = Session.query(Workflow).filter(Workflow.id_ == workflow_uuid).first()
         # create file
         file_name = "dataset.csv"
         file_binary_content = b"1,2,3,4\n5,6,7,8"
@@ -1433,7 +1452,11 @@ def test_start_input_parameters(
         workflow_created_uuid = sample_serial_workflow_in_db.id_
         session.add(sample_serial_workflow_in_db)
         session.commit()
-        workflow = Workflow.query.filter(Workflow.id_ == workflow_created_uuid).first()
+        workflow = (
+            Session.query(Workflow)
+            .filter(Workflow.id_ == workflow_created_uuid)
+            .first()
+        )
         assert workflow.status == RunStatus.created
         payload = START
         parameters = {"input_parameters": {"first": "test"}, "operational_options": {}}
@@ -1458,9 +1481,11 @@ def test_start_input_parameters(
                 )
                 json_response = json.loads(res.data.decode())
                 assert json_response.get("status") == status_dict[payload].name
-                workflow = Workflow.query.filter(
-                    Workflow.id_ == workflow_created_uuid
-                ).first()
+                workflow = (
+                    Session.query(Workflow)
+                    .filter(Workflow.id_ == workflow_created_uuid)
+                    .first()
+                )
                 assert workflow.input_parameters == parameters["input_parameters"]
 
 
@@ -1505,7 +1530,7 @@ def test_start_no_input_parameters(
                 )
         json_response = json.loads(res.data.decode())
         assert json_response["status"] == status_dict[payload].name
-        workflow = Workflow.query.filter(Workflow.id_ == workflow_uuid).first()
+        workflow = Session.query(Workflow).filter(Workflow.id_ == workflow_uuid).first()
         assert workflow.input_parameters == dict()
 
 
@@ -1664,9 +1689,11 @@ def test_workspace_deletion(
         assert res.status_code == 201
         response_data = json.loads(res.get_data(as_text=True))
 
-        workflow = Workflow.query.filter(
-            Workflow.id_ == response_data.get("workflow_id")
-        ).first()
+        workflow = (
+            Session.query(Workflow)
+            .filter(Workflow.id_ == response_data.get("workflow_id"))
+            .first()
+        )
         assert workflow
 
         # create a job for the workflow
@@ -1694,9 +1721,9 @@ def test_workspace_deletion(
 
         # check that all cache entries for jobs
         # of the deleted workflow are removed
-        cache_entries_after_delete = JobCache.query.filter_by(
-            job_id=workflow_job.id_
-        ).all()
+        cache_entries_after_delete = (
+            Session.query(JobCache).filter_by(job_id=workflow_job.id_).all()
+        )
         assert not cache_entries_after_delete
 
 
@@ -1717,9 +1744,11 @@ def test_deletion_of_workspace_of_an_already_deleted_workflow(
         assert res.status_code == 201
         response_data = json.loads(res.get_data(as_text=True))
 
-        workflow = Workflow.query.filter(
-            Workflow.id_ == response_data.get("workflow_id")
-        ).first()
+        workflow = (
+            Session.query(Workflow)
+            .filter(Workflow.id_ == response_data.get("workflow_id"))
+            .first()
+        )
         assert workflow
 
         # check that the workflow workspace exists

--- a/tests/test_workflow_run_manager.py
+++ b/tests/test_workflow_run_manager.py
@@ -15,6 +15,7 @@ from kubernetes.client.rest import ApiException
 from mock import DEFAULT, Mock, patch
 
 from reana_commons.config import KRB5_INIT_CONTAINER_NAME
+from reana_db.database import Session
 from reana_db.models import (
     RunStatus,
     InteractiveSession,
@@ -156,10 +157,14 @@ def test_interactive_session_closure(sample_serial_workflow_in_db, session):
                 InteractiveSessionType(0).name, expose_secrets=False
             )
 
-            int_session = InteractiveSession.query.filter_by(
-                owner_id=workflow.owner_id,
-                type_=InteractiveSessionType(0).name,
-            ).first()
+            int_session = (
+                Session.query(InteractiveSession)
+                .filter_by(
+                    owner_id=workflow.owner_id,
+                    type_=InteractiveSessionType(0).name,
+                )
+                .first()
+            )
             assert int_session.status == RunStatus.created
             kwrm.stop_interactive_session(int_session.id_)
             assert not workflow.sessions.first()

--- a/tests/test_workspace_limits.py
+++ b/tests/test_workspace_limits.py
@@ -45,14 +45,14 @@ def _create_files(workspace_path, paths):
 def _mock_workspace_access(monkeypatch, workspace_path):
     """Mock user and workflow lookups for workspace route tests."""
 
-    class _UserQuery:
+    class _Query:
         def filter(self, *args, **kwargs):
             return self
 
         def first(self):
             return SimpleNamespace(id_="user-1")
 
-    monkeypatch.setattr(workflows_workspace.User, "query", _UserQuery(), raising=False)
+    monkeypatch.setattr(workflows_workspace.Session, "query", lambda *a, **kw: _Query())
     monkeypatch.setattr(
         workflows_workspace,
         "_get_workflow_with_uuid_or_name",


### PR DESCRIPTION
Upgrade Flask from `<2.3.0` to `>=3.0.0` and Werkzeug from `<2.3.0` to `>=3.0.0`, in line with the Invenio package upgrade in reana-server. Bump marshmallow from `<3.0.0` to `>=3.5.0,<4.0.0` and webargs to `>=8.0`, since the new Invenio stack requires marshmallow 3 and the corresponding webargs 8.

Adapt the REST endpoints to the new marshmallow 3 and webargs 8 APIs. Replace the deprecated `missing=` keyword on schema fields with `load_default=`. Add `unknown=marshmallow.EXCLUDE` to all `@use_kwargs` and `@use_args` decorators that parse query parameters, so that REANA-specific extras such as `access_token` are silently ignored, matching the pre-upgrade webargs 5 behaviour.

Replace all remaining `Model.query` call sites in the REST handlers, the workflow run manager, and the test suite with explicit `Session.query(Model)` queries, since SQLAlchemy 2.x no longer supports the `Base.query` shortcut.

Replace the deprecated `FLASK_ENV` setting with `FLASK_DEBUG`, both in the runtime checks of the workflow run manager and in the `DEBUG_ENV_VARS` injected into spawned workflow engine containers. Update the test configuration to use `DEBUG` instead of `FLASK_ENV`.

Remove pinned `reana-commons`, `reana-db`, and `kubernetes` entries from `requirements.txt` so that `pip install .` resolves them freshly from `setup.py` against the locally-mounted `modules/reana-db` and `modules/reana-commons` shared sources during development, avoiding version conflicts with PyPI versions that still carry the old pins.

Closes reanahub/reana-server#770.