### PR TITLE
refactor(pytest): drop pytest-reana for reana-commons[tests]

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
-addopts = --ignore=docs --cov=reana_workflow_controller --cov-report=term-missing --cov-report=xml
+addopts = --ignore=docs --ignore=modules --cov=reana_workflow_controller --cov-report=term-missing --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@
 alembic==1.18.4           # via reana-db
 amqp==5.3.1               # via kombu
 appdirs==1.4.4            # via fs
-arrow==1.4.0              # via isoduration
-attrs==26.1.0             # via jsonschema, referencing
+attrs==26.1.0             # via jsonschema
 blinker==1.9.0            # via flask
 bracex==2.6               # via wcmatch
 bravado==10.3.2           # via reana-commons
@@ -18,29 +17,26 @@ cffi==2.0.0               # via cryptography
 charset-normalizer==3.4.7  # via requests
 checksumdir==1.1.9        # via reana-commons
 click==8.3.3              # via flask, reana-commons
-cryptography==47.0.0      # via sqlalchemy-utils
+cryptography==48.0.0      # via sqlalchemy-utils
 durationpy==0.10          # via kubernetes
 events==0.5               # via opensearch-py
 flask==3.1.3              # via reana-workflow-controller (setup.py)
-fqdn==1.5.1               # via jsonschema
 fs==2.4.16                # via reana-commons
-gherkin-official==39.0.0  # via reana-commons
+gherkin-official==39.1.0  # via reana-commons
 gitdb==4.0.12             # via gitpython
-gitpython==3.1.48         # via reana-workflow-controller (setup.py)
+gitpython==3.1.50         # via reana-workflow-controller (setup.py)
 greenlet==3.5.0           # via sqlalchemy
-idna==3.13                # via jsonschema, requests
+idna==3.14                # via jsonschema, requests
 importlib-resources==7.1.0  # via swagger-spec-validator
-isoduration==20.11.0      # via jsonschema
 itsdangerous==2.2.0       # via flask
 jinja2==3.1.6             # via flask
 jsonpickle==4.1.1         # via reana-workflow-controller (setup.py)
 jsonpointer==3.1.1        # via jsonschema
 jsonref==1.1.0            # via bravado-core
-jsonschema[format]==4.26.0  # via bravado-core, reana-commons, swagger-spec-validator
-jsonschema-specifications==2025.9.1  # via jsonschema
+jsonschema[format]==3.2.0  # via bravado-core, reana-commons, swagger-spec-validator
 kombu==5.6.2              # via reana-commons
 kubernetes==35.0.0        # via reana-commons
-mako==1.3.11              # via alembic
+mako==1.3.12              # via alembic
 markupsafe==3.0.3         # via flask, jinja2, mako, werkzeug
 marshmallow==3.26.2       # via reana-workflow-controller (setup.py), webargs
 mock==3.0.5               # via reana-commons
@@ -50,31 +46,29 @@ msgpack-python==0.5.6     # via bravado
 oauthlib==3.3.1           # via requests-oauthlib
 opensearch-py==2.7.1      # via reana-workflow-controller (setup.py)
 packaging==26.2           # via kombu, marshmallow, reana-workflow-controller (setup.py), webargs
-parse==1.21.1             # via reana-commons
+parse==1.22.0             # via reana-commons
 psycopg2-binary==2.9.12   # via reana-db
 pycparser==3.0            # via cffi
-python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, kubernetes, opensearch-py
-pytz==2026.1.post1        # via bravado-core
+pyrsistent==0.20.0        # via jsonschema
+python-dateutil==2.9.0.post0  # via bravado, bravado-core, kubernetes, opensearch-py
+pytz==2026.2              # via bravado-core
 pyuwsgi==2.0.30.post1     # via reana-workflow-controller (setup.py)
 pyyaml==6.0.3             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.95.0a17	# via reana-db, reana-workflow-controller (setup.py)
-reana-db==0.95.0a9	# via reana-workflow-controller (setup.py)
-referencing==0.37.0       # via jsonschema, jsonschema-specifications
-requests==2.33.1          # via bravado, bravado-core, kubernetes, opensearch-py, reana-workflow-controller (setup.py), requests-oauthlib
+reana-commons[kubernetes]==0.95.0a17  # via reana-db, reana-workflow-controller (setup.py)
+reana-db==0.95.0a9        # via reana-workflow-controller (setup.py)
+requests==2.34.0          # via bravado, bravado-core, kubernetes, opensearch-py, reana-workflow-controller (setup.py), requests-oauthlib
 requests-oauthlib==2.0.0  # via kubernetes
-rfc3339-validator==0.1.4  # via jsonschema
 rfc3987==1.3.8            # via jsonschema
-rpds-py==0.30.0           # via jsonschema, referencing
 simplejson==4.1.1         # via bravado, bravado-core
-six==1.17.0               # via bravado, bravado-core, fs, kubernetes, mock, python-dateutil, rfc3339-validator
+six==1.17.0               # via bravado, bravado-core, fs, jsonschema, kubernetes, mock, python-dateutil
 smmap==5.0.3              # via gitdb
 sqlalchemy==2.0.49        # via alembic, reana-db, sqlalchemy-utils
 sqlalchemy-utils[encrypted]==0.41.2  # via reana-db, reana-workflow-controller (setup.py)
+strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==3.0.4  # via bravado-core
-typing-extensions==4.15.0  # via alembic, bravado, gherkin-official, referencing, sqlalchemy, swagger-spec-validator
-tzdata==2026.2            # via arrow, kombu
-uri-template==1.3.0       # via jsonschema
-urllib3==2.6.3            # via kubernetes, opensearch-py, requests
+typing-extensions==4.15.0  # via alembic, bravado, gherkin-official, sqlalchemy, swagger-spec-validator
+tzdata==2026.2            # via kombu
+urllib3==2.7.0            # via kubernetes, opensearch-py, requests
 uwsgi-tools==1.1.1        # via reana-workflow-controller (setup.py)
 uwsgitop==0.12            # via reana-workflow-controller (setup.py)
 vine==5.1.0               # via amqp, kombu

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,8 +57,8 @@ python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, kubernetes, op
 pytz==2026.1.post1        # via bravado-core
 pyuwsgi==2.0.30.post1     # via reana-workflow-controller (setup.py)
 pyyaml==6.0.3             # via bravado, bravado-core, kubernetes, reana-commons, swagger-spec-validator
-reana-commons[kubernetes]==0.95.0a15  # via reana-db, reana-workflow-controller (setup.py)
-reana-db==0.95.0a8        # via reana-workflow-controller (setup.py)
+reana-commons[kubernetes]==0.95.0a17	# via reana-db, reana-workflow-controller (setup.py)
+reana-db==0.95.0a9	# via reana-workflow-controller (setup.py)
 referencing==0.37.0       # via jsonschema, jsonschema-specifications
 requests==2.33.1          # via bravado, bravado-core, kubernetes, opensearch-py, reana-workflow-controller (setup.py), requests-oauthlib
 requests-oauthlib==2.0.0  # via kubernetes

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,10 @@ extras_require = {
         "sphinxcontrib-redoc>=1.5.1",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a9,<0.96.0",
+        "apispec[yaml]>=3.0",
+        "apispec-webframeworks",
+        "reana-commons[kubernetes,tests]>=0.95.0a17,<0.96.0",
+        "reana-db[tests]>=0.95.0a9,<0.96.0",
     ],
 }
 
@@ -51,8 +54,8 @@ install_requires = [
     "marshmallow>=3.5.0,<4.0.0",
     "opensearch-py>=2.7.0,<2.8.0",
     "packaging>=18.0",
-    "reana-commons[kubernetes]>=0.95.0a15,<0.96.0",
-    "reana-db>=0.95.0a8,<0.96.0",
+    "reana-commons[kubernetes]>=0.95.0a17,<0.96.0",
+    "reana-db>=0.95.0a9,<0.96.0",
     "requests>=2.25.0",
     "sqlalchemy-utils>=0.31.0",
     "uwsgi-tools>=1.1.1",


### PR DESCRIPTION
Replace pytest-reana in extras_require[tests] with
reana-commons[kubernetes,tests] and reana-db[tests]. Pytest fixtures
used by the test suite are auto-loaded via the pytest11 entry points
the two libraries now register, so tests/conftest.py needs no change.

Closes https://github.com/reanahub/pytest-reana/issues/156