### PR TITLE
feat(docker): externalise uWSGI controller configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -69,43 +69,20 @@ RUN if test -e modules/reana-commons; then \
 # Check for any broken Python dependencies
 RUN pip check
 
+# Install the default uWSGI configuration. Cluster deployments override it
+# by mounting the Helm-managed ConfigMap at the same path.
+COPY etc/uwsgi.ini /var/reana/uwsgi/uwsgi.ini
+
 # Set useful environment variables
-ARG UWSGI_BUFFER_SIZE=8192
-ARG UWSGI_MAX_FD=1048576
-ARG UWSGI_PROCESSES=2
-ARG UWSGI_THREADS=2
 ENV FLASK_APP=reana_workflow_controller/app.py \
     PYTHONPATH=/workdir \
-    TERM=xterm \
-    UWSGI_BUFFER_SIZE=${UWSGI_BUFFER_SIZE:-8192} \
-    UWSGI_MAX_FD=${UWSGI_MAX_FD:-1048576} \
-    UWSGI_PROCESSES=${UWSGI_PROCESSES:-2} \
-    UWSGI_THREADS=${UWSGI_THREADS:-2}
+    TERM=xterm
 
 # Expose ports to clients
 EXPOSE 5000
 
-# Run server
-# exec is used to make sure signals are propagated to uwsgi,
-# while also allowing shell expansion
-# hadolint ignore=DL3025
-CMD exec uwsgi \
-    --buffer-size ${UWSGI_BUFFER_SIZE} \
-    --die-on-term \
-    --hook-master-start "unix_signal:2 gracefully_kill_them_all" \
-    --hook-master-start "unix_signal:15 gracefully_kill_them_all" \
-    --enable-threads \
-    --http-socket 0.0.0.0:5000 \
-    --master \
-    --max-fd ${UWSGI_MAX_FD} \
-    --module reana_workflow_controller.app:app \
-    --need-app \
-    --processes ${UWSGI_PROCESSES} \
-    --single-interpreter \
-    --stats /tmp/stats.socket \
-    --threads ${UWSGI_THREADS} \
-    --vacuum \
-    --wsgi-disable-file-wrapper
+# Run server (use Flask when FLASK_DEBUG is set, otherwise use uWSGI)
+CMD ["/bin/sh", "-c", "case \"$(printf '%s' \"${FLASK_DEBUG}\" | tr '[:upper:]' '[:lower:]')\" in 1|true) exec flask run -h 0.0.0.0 ;; *) exec uwsgi --ini /var/reana/uwsgi/uwsgi.ini ;; esac"]
 
 # Set image labels
 LABEL org.opencontainers.image.authors="team@reanahub.io"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2024 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -24,6 +24,7 @@ recursive-include docs *.py
 recursive-include docs *.png
 recursive-include docs *.md
 recursive-include docs *.txt
+recursive-include etc *.ini
 recursive-include reana_workflow_controller *.html
 recursive-include reana_workflow_controller *.py
 recursive-include reana_workflow_controller/templates *.template

--- a/etc/uwsgi.ini
+++ b/etc/uwsgi.ini
@@ -1,0 +1,20 @@
+[uwsgi]
+stats = /tmp/stats.socket
+http = 0.0.0.0:5000
+module = reana_workflow_controller.app:app
+master = true
+processes = 2
+threads = 2
+enable-threads = true
+single-interpreter = true
+need-app = true
+vacuum = true
+wsgi-disable-file-wrapper = true
+
+buffer-size = 8192
+
+die-on-term = true
+hook-master-start = unix_signal:2 gracefully_kill_them_all
+hook-master-start = unix_signal:15 gracefully_kill_them_all
+
+max-fd = 1048576

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -851,7 +851,15 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
             )
 
         secrets_volume_mount = user_secrets.get_secrets_volume_mount_as_k8s_spec()
-        job_controller_container.volume_mounts = [workspace_mount, secrets_volume_mount]
+        uwsgi_config_mount = {
+            "name": "uwsgi-config-reana-job-controller",
+            "mountPath": "/var/reana/uwsgi",
+        }
+        job_controller_container.volume_mounts = [
+            workspace_mount,
+            secrets_volume_mount,
+            uwsgi_config_mount,
+        ]
 
         job_controller_container.ports = [
             {"containerPort": current_app.config["JOB_CONTROLLER_CONTAINER_PORT"]}
@@ -866,9 +874,17 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         spec.template.spec.service_account_name = (
             REANA_RUNTIME_KUBERNETES_SERVICEACCOUNT_NAME
         )
+        uwsgi_config_volume = {
+            "name": "uwsgi-config-reana-job-controller",
+            "configMap": {
+                "defaultMode": 420,
+                "name": "uwsgi-config-reana-job-controller",
+            },
+        }
         volumes = [
             workspace_volume,
             user_secrets.get_file_secrets_volume_as_k8s_specs(),
+            uwsgi_config_volume,
         ]
 
         if kerberos:
@@ -909,7 +925,11 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
 
     def _create_job_controller_startup_cmd(self, user=None):
         """Create job controller startup cmd."""
-        base_cmd = "exec flask run -h 0.0.0.0;"
+        if os.getenv("FLASK_DEBUG", "").lower() in ("1", "true"):
+            base_cmd = "exec flask run -h 0.0.0.0;"
+        else:
+            base_cmd = "exec uwsgi --ini /var/reana/uwsgi/uwsgi.ini;"
+
         if user:
             add_group_cmd = (
                 "getent group '{gid}' || groupadd -f -g '{gid}' '{name}';".format(

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,8 @@ install_requires = [
     "requests>=2.25.0",
     "sqlalchemy-utils>=0.31.0",
     "uwsgi-tools>=1.1.1",
-    "pyuwsgi>=2.0.17",
-    "uwsgitop>=0.10",
+    "pyuwsgi>=2.0.28",
+    "uwsgitop>=0.12",
     "webargs>=8.0",
 ]
 


### PR DESCRIPTION
Switch reana-workflow-controller and the job-controller pods it spawns
to INI-based uWSGI startup. This replaces the inline workflow-controller
options and the job-controller Flask development server.

Mount the Helm-managed job-controller configuration at /var/reana/uwsgi,
retain Flask startup for debug mode, and align FLASK_DEBUG handling
between the Dockerfile and Python startup logic.

Ship a default workflow-controller configuration for standalone
containers, and bump the pyuwsgi and uwsgitop minimum versions.

Depends on reanahub/reana#953, which provides both production ConfigMaps
and mounts the workflow-controller one. The job-controller mount is
added here.

Closes reanahub/reana#952
