### PR TITLE
feat(config): propagate minimum Kubernetes job user ID env var

### DIFF
--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -192,6 +192,13 @@ REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT = os.getenv(
 
 Please see the following URL for more details
 https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup.
+"""
+
+REANA_KUBERNETES_JOBS_MIN_USER_UID = os.getenv("REANA_KUBERNETES_JOBS_MIN_USER_UID")
+"""Minimum accepted user runtime container UID that users can assign to their job
+containers via ``kubernetes_uid`` in ``reana.yaml``. Jobs requesting a smaller
+UID are refused at submission time with a clear error message. Forwarded to
+reana-job-controller via the job batch pod environment.
 """
 
 WORKFLOW_ENGINE_COMMON_ENV_VARS = [

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -86,6 +86,7 @@ from reana_workflow_controller.config import (  # isort:skip
     REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_REQUEST,
     REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT,
     REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT,
+    REANA_KUBERNETES_JOBS_MIN_USER_UID,
     REANA_WORKFLOW_ENGINE_IMAGE_CWL,
     REANA_WORKFLOW_ENGINE_IMAGE_SERIAL,
     REANA_WORKFLOW_ENGINE_IMAGE_SNAKEMAKE,
@@ -818,6 +819,13 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                 {"name": "WORKSPACE_PATHS", "value": json.dumps(WORKSPACE_PATHS)},
             ]
         )
+        if REANA_KUBERNETES_JOBS_MIN_USER_UID:
+            job_controller_container.env.append(
+                {
+                    "name": "REANA_KUBERNETES_JOBS_MIN_USER_UID",
+                    "value": REANA_KUBERNETES_JOBS_MIN_USER_UID,
+                },
+            )
         # env vars coming from Helm values are added after the ones from r-w-controller
         # so that the former can override the latter in case of necessity
         job_controller_container.env.extend(copy.deepcopy(JOB_CONTROLLER_ENV_VARS))


### PR DESCRIPTION
Read `REANA_KUBERNETES_JOBS_MIN_USER_UID` from the environment and forward it to the workflow batch pod so that reana-job-controller can honour the cluster-configured minimum when handling user-supplied `kubernetes_uid` workflow hints.

Closes reanahub/reana#951