### PR TITLE
feat(manager): set runAsNonRoot on workflow-engine container

### DIFF
--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -705,6 +705,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         workflow_engine_container.security_context = client.V1SecurityContext(
             run_as_group=WORKFLOW_RUNTIME_USER_GID,
             run_as_user=WORKFLOW_RUNTIME_USER_UID,
+            run_as_non_root=True,
             allow_privilege_escalation=False,
         )
         workflow_engine_container.volume_mounts = [workspace_mount]


### PR DESCRIPTION
Set `runAsNonRoot: true` on the workflow-engine container's security
context, so Kubernetes refuses to schedule the pod if a future code
path would let UID 0 reach the spec. Today, `run_as_user` is set to
`WORKFLOW_RUNTIME_USER_UID` (1000); this is just a defence-in-depth
change at the cluster layer, complementing the existing
application-level UID guards.

The interactive-session deployment (`k8s.py`) is left untouched on
purpose: its container-level security context is separate, so no
opt-out is needed for the deliberate root path there.