### PR TITLE
feat(manager): harden workflow run and session pods

### DIFF
--- a/reana_workflow_controller/config.py
+++ b/reana_workflow_controller/config.py
@@ -482,8 +482,59 @@ def _parse_comma_separated_list(value: str) -> List[str]:
     return [x.strip() for x in value.split(",") if x.strip()]
 
 
+_VALID_RUNTIME_FS_GROUP_CHANGE_POLICIES = {"Always", "OnRootMismatch"}
+"""Valid REANA runtime pod fsGroup change policy values."""
+
+
+def _parse_runtime_fs_group_change_policy(value: str | None) -> str:
+    """Parse runtime pod fsGroup change policy configuration."""
+    policy = (value or "").strip()
+    if not policy:
+        return "OnRootMismatch"
+    if policy not in _VALID_RUNTIME_FS_GROUP_CHANGE_POLICIES:
+        valid_values = ", ".join(sorted(_VALID_RUNTIME_FS_GROUP_CHANGE_POLICIES))
+        raise ValueError(
+            "Invalid REANA_RUNTIME_FS_GROUP_CHANGE_POLICY value: "
+            f"{policy}. Valid values: {valid_values}"
+        )
+    return policy
+
+
+def _parse_runtime_sessions_supplemental_groups(value: str | None) -> List[int]:
+    """Parse supplemental groups for runtime interactive-session pods."""
+    raw_groups = "100" if value is None else value
+    parsed_groups = []
+    for group_value in _parse_comma_separated_list(raw_groups):
+        try:
+            group_id = int(group_value)
+        except ValueError as exc:
+            raise ValueError(
+                "Invalid REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS value: "
+                f"{group_value}. Values must be non-negative integers."
+            ) from exc
+        if group_id < 0:
+            raise ValueError(
+                "Invalid REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS value: "
+                f"{group_value}. Values must be non-negative integers."
+            )
+        parsed_groups.append(group_id)
+    return parsed_groups
+
+
 WORKSPACE_DISPLAY_FILE_LIMIT = int(os.getenv("WORKSPACE_DISPLAY_FILE_LIMIT", "100000"))
 """Maximum number of file entries returned by workspace listing endpoints."""
+
+REANA_RUNTIME_FS_GROUP_CHANGE_POLICY = _parse_runtime_fs_group_change_policy(
+    os.getenv("REANA_RUNTIME_FS_GROUP_CHANGE_POLICY")
+)
+"""Policy controlling runtime pod fsGroup ownership updates."""
+
+REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS = (
+    _parse_runtime_sessions_supplemental_groups(
+        os.getenv("REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS")
+    )
+)
+"""Supplemental groups applied to interactive-session pods."""
 
 _VALID_GC_COMMANDS = {"ls", "list", "rm", "delete"}
 """Valid FORCE_GARBAGE_COLLECTION command values."""

--- a/reana_workflow_controller/dask.py
+++ b/reana_workflow_controller/dask.py
@@ -20,8 +20,10 @@ from reana_db.utils import _get_workflow_with_uuid_or_name
 from reana_commons.config import (
     K8S_CERN_EOS_AVAILABLE,
     K8S_CERN_EOS_MOUNT_CONFIGURATION,
+    K8S_USE_SECURITY_CONTEXT,
     KRB5_STATUS_FILE_LOCATION,
     REANA_JOB_HOSTPATH_MOUNTS,
+    WORKFLOW_RUNTIME_USER_GID,
     WORKFLOW_RUNTIME_USER_UID,
     REANA_RUNTIME_KUBERNETES_NAMESPACE,
     REANA_RUNTIME_JOBS_KUBERNETES_NODE_LABEL,
@@ -30,7 +32,6 @@ from reana_commons.k8s.api_client import (
     current_k8s_networking_api_client,
     current_k8s_custom_objects_api_client,
 )
-from reana_commons.k8s.kerberos import get_kerberos_k8s_config
 from reana_commons.k8s.secrets import UserSecretsStore
 from reana_commons.k8s.volumes import (
     get_workspace_volume,
@@ -43,9 +44,38 @@ from reana_workflow_controller.config import (
     REANA_INGRESS_HOST,
     REANA_INGRESS_CLASS_NAME,
     REANA_INGRESS_ANNOTATIONS,
+    REANA_RUNTIME_FS_GROUP_CHANGE_POLICY,
     TRAEFIK_ENABLED,
     TRAEFIK_EXTERNAL,
 )
+from reana_workflow_controller.k8s import get_compatible_kerberos_k8s_config
+
+
+def _restricted_pod_security_context(kubernetes_uid: int) -> dict:
+    """Return a pod security context for non-root Dask pods."""
+    return {
+        "fsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+        "fsGroupChangePolicy": REANA_RUNTIME_FS_GROUP_CHANGE_POLICY,
+        "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+        "runAsUser": int(kubernetes_uid),
+        "runAsNonRoot": True,
+    }
+
+
+def _restricted_container_security_context(
+    kubernetes_uid: int | None = None,
+) -> dict:
+    """Return a PSA-restricted container security context."""
+    security_context = {
+        "runAsNonRoot": True,
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+    if kubernetes_uid is not None:
+        security_context["runAsGroup"] = int(WORKFLOW_RUNTIME_USER_GID)
+        security_context["runAsUser"] = int(kubernetes_uid)
+    return security_context
 
 
 class DaskResourceManager:
@@ -96,7 +126,7 @@ class DaskResourceManager:
         self.secrets_volume_mount = (
             self.secrets_store.get_secrets_volume_mount_as_k8s_spec()
         )
-        self.kubernetes_uid = WORKFLOW_RUNTIME_USER_UID
+        self.kubernetes_uid = int(WORKFLOW_RUNTIME_USER_UID)
 
         self.kerberos = kerberos
         self.voms_proxy = voms_proxy
@@ -213,6 +243,20 @@ class DaskResourceManager:
                 "nodeSelector"
             ] = REANA_RUNTIME_JOBS_KUBERNETES_NODE_LABEL
 
+        if K8S_USE_SECURITY_CONTEXT:
+            self.cluster_body["spec"]["scheduler"]["spec"]["securityContext"] = (
+                _restricted_pod_security_context(self.kubernetes_uid)
+            )
+            self.cluster_body["spec"]["worker"]["spec"]["securityContext"] = (
+                _restricted_pod_security_context(self.kubernetes_uid)
+            )
+            self.cluster_body["spec"]["scheduler"]["spec"]["containers"][0][
+                "securityContext"
+            ] = _restricted_container_security_context()
+            self.cluster_body["spec"]["worker"]["spec"]["containers"][0][
+                "securityContext"
+            ] = _restricted_container_security_context()
+
         # Add secrets
         self.cluster_body["spec"]["worker"]["spec"]["containers"][0]["env"].extend(
             self.secret_env_vars
@@ -315,7 +359,7 @@ class DaskResourceManager:
 
     def _add_krb5_containers(self):
         """Add krb5 init and renew containers for Dask workers."""
-        krb5_config = get_kerberos_k8s_config(
+        krb5_config = get_compatible_kerberos_k8s_config(
             self.secrets_store,
             kubernetes_uid=self.kubernetes_uid,
         )
@@ -404,11 +448,9 @@ class DaskResourceManager:
                         echo "[ERROR] VOMSPROXY_FILE {voms_proxy_user_file} does not exist in user secrets."; \
                         exit; \
                      fi; \
-                     cp /etc/reana/secrets/{voms_proxy_user_file} {voms_proxy_file_path}; \
-                     chown {kubernetes_uid} {voms_proxy_file_path}'.format(
+                     cp /etc/reana/secrets/{voms_proxy_user_file} {voms_proxy_file_path}'.format(
                         voms_proxy_user_file=voms_proxy_user_file,
                         voms_proxy_file_path=voms_proxy_file_path,
-                        kubernetes_uid=self.kubernetes_uid,
                     ),
                 ],
                 "name": current_app.config["VOMSPROXY_CONTAINER_NAME"],
@@ -416,6 +458,10 @@ class DaskResourceManager:
                 "volumeMounts": [self.secrets_volume_mount] + volume_mounts,
                 "env": self.secret_env_vars,
             }
+            if K8S_USE_SECURITY_CONTEXT:
+                voms_proxy_container["securityContext"] = (
+                    _restricted_container_security_context(self.kubernetes_uid)
+                )
         else:
             # single-user deployment mode, where we generate VOMS proxy file in the sidecar from user secrets
             voms_proxy_container = {
@@ -444,12 +490,10 @@ class DaskResourceManager:
                          echo {voms_proxy_pass} | base64 -d | voms-proxy-init \
                          --voms {voms_proxy_vo} --key /tmp/userkey.pem \
                          --cert $(readlink -f /etc/reana/secrets/usercert.pem) \
-                         --pwstdin --out {voms_proxy_file_path}; \
-                         chown {kubernetes_uid} {voms_proxy_file_path}'.format(
+                         --pwstdin --out {voms_proxy_file_path}'.format(
                         voms_proxy_vo=voms_proxy_vo.lower(),
                         voms_proxy_file_path=voms_proxy_file_path,
                         voms_proxy_pass=voms_proxy_pass,
-                        kubernetes_uid=self.kubernetes_uid,
                     ),
                 ],
                 "name": current_app.config["VOMSPROXY_CONTAINER_NAME"],
@@ -457,6 +501,10 @@ class DaskResourceManager:
                 "volumeMounts": [self.secrets_volume_mount] + volume_mounts,
                 "env": self.secret_env_vars,
             }
+            if K8S_USE_SECURITY_CONTEXT:
+                voms_proxy_container["securityContext"] = (
+                    _restricted_container_security_context(self.kubernetes_uid)
+                )
 
         self.cluster_body["spec"]["worker"]["spec"]["volumes"].extend(
             [ticket_cache_volume]
@@ -572,6 +620,10 @@ class DaskResourceManager:
             "volumeMounts": [self.secrets_volume_mount] + volume_mounts,
             "env": self.secret_env_vars,
         }
+        if K8S_USE_SECURITY_CONTEXT:
+            rucio_config_container["securityContext"] = (
+                _restricted_container_security_context(self.kubernetes_uid)
+            )
 
         self.cluster_body["spec"]["worker"]["spec"]["volumes"].extend(
             [ticket_cache_volume]

--- a/reana_workflow_controller/k8s.py
+++ b/reana_workflow_controller/k8s.py
@@ -9,15 +9,19 @@
 from kubernetes import client
 from kubernetes.client.rest import ApiException
 from reana_commons.config import (
+    K8S_USE_SECURITY_CONTEXT,
     REANA_WORKFLOW_UMASK,
     REANA_RUNTIME_SESSIONS_KUBERNETES_NODE_LABEL,
     REANA_RUNTIME_KUBERNETES_NAMESPACE,
+    WORKFLOW_RUNTIME_USER_GID,
+    WORKFLOW_RUNTIME_USER_UID,
 )
 from reana_commons.k8s.api_client import (
     current_k8s_appsv1_api_client,
     current_k8s_corev1_api_client,
     current_k8s_networking_api_client,
 )
+from reana_commons.k8s.kerberos import get_kerberos_k8s_config
 from reana_commons.k8s.secrets import UserSecretsStore
 from reana_commons.k8s.volumes import (
     get_k8s_cvmfs_volumes,
@@ -29,7 +33,97 @@ from reana_workflow_controller.config import (  # isort:skip
     REANA_INGRESS_ANNOTATIONS,
     REANA_INGRESS_CLASS_NAME,
     REANA_INGRESS_HOST,
+    REANA_RUNTIME_FS_GROUP_CHANGE_POLICY,
+    REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS,
 )
+
+
+def _restricted_session_pod_security_context() -> client.V1PodSecurityContext | None:
+    """Return the pod security context for interactive sessions."""
+    if not K8S_USE_SECURITY_CONTEXT:
+        return None
+    pod_security_context_kwargs = dict(
+        fs_group=int(WORKFLOW_RUNTIME_USER_GID),
+        fs_group_change_policy=REANA_RUNTIME_FS_GROUP_CHANGE_POLICY,
+    )
+    if REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS:
+        pod_security_context_kwargs["supplemental_groups"] = (
+            REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS
+        )
+    return client.V1PodSecurityContext(**pod_security_context_kwargs)
+
+
+def _restricted_session_container_security_context() -> client.V1SecurityContext | None:
+    """Return the container security context for interactive sessions."""
+    if not K8S_USE_SECURITY_CONTEXT:
+        return None
+    return client.V1SecurityContext(
+        run_as_group=int(WORKFLOW_RUNTIME_USER_GID),
+        run_as_user=int(WORKFLOW_RUNTIME_USER_UID),
+        run_as_non_root=True,
+        allow_privilege_escalation=False,
+        capabilities=client.V1Capabilities(drop=["ALL"]),
+        seccomp_profile=client.V1SeccompProfile(type="RuntimeDefault"),
+    )
+
+
+def _restricted_kerberos_container_security_context(kubernetes_uid: int) -> dict:
+    """Return the expected PSA-restricted security context for Kerberos containers."""
+    return {
+        "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+        "runAsUser": int(kubernetes_uid),
+        "runAsNonRoot": True,
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+
+
+def _normalize_kerberos_container_security_context(
+    kerberos_config, kubernetes_uid: int
+):
+    """Backfill missing Kerberos security-context fields from older commons releases."""
+    if not K8S_USE_SECURITY_CONTEXT:
+        return kerberos_config
+
+    for container_name in ("init_container", "renew_container"):
+        container = getattr(kerberos_config, container_name, None)
+        if not container:
+            continue
+
+        expected_security_context = _restricted_kerberos_container_security_context(
+            kubernetes_uid
+        )
+        if "securityContext" not in container:
+            container["securityContext"] = expected_security_context
+            continue
+
+        for field, value in expected_security_context.items():
+            if field not in container["securityContext"]:
+                container["securityContext"][field] = value
+
+    return kerberos_config
+
+
+def get_compatible_kerberos_k8s_config(user_secrets, kubernetes_uid: int):
+    """Return Kerberos k8s config across released and unreleased commons APIs."""
+    try:
+        kerberos_config = get_kerberos_k8s_config(
+            user_secrets,
+            kubernetes_uid=kubernetes_uid,
+            use_security_context=K8S_USE_SECURITY_CONTEXT,
+        )
+    except TypeError as exc:
+        if "unexpected keyword argument 'use_security_context'" not in str(exc):
+            raise
+        kerberos_config = get_kerberos_k8s_config(
+            user_secrets,
+            kubernetes_uid=kubernetes_uid,
+        )
+    return _normalize_kerberos_container_security_context(
+        kerberos_config,
+        kubernetes_uid,
+    )
 
 
 class InteractiveDeploymentK8sBuilder(object):
@@ -90,6 +184,7 @@ class InteractiveDeploymentK8sBuilder(object):
             # not polluted with variables like `REANA_SERVER_SERVICE_HOST`
             enable_service_links=False,
             automount_service_account_token=False,
+            security_context=_restricted_session_pod_security_context(),
         )
 
         self.kubernetes_objects = {
@@ -222,12 +317,11 @@ class InteractiveDeploymentK8sBuilder(object):
         env_var = client.V1EnvVar(name, str(value))
         self._session_container.env.append(env_var)
 
-    def add_run_with_root_permissions(self):
-        """Run interactive session with root."""
-        security_context = client.V1SecurityContext(
-            run_as_user=0, allow_privilege_escalation=False
+    def add_run_with_runtime_user_permissions(self):
+        """Run interactive session with the default non-root REANA user."""
+        self._session_container.security_context = (
+            _restricted_session_container_security_context()
         )
-        self._session_container.security_context = security_context
 
     def add_user_secrets(self):
         """Mount the "file" secrets and set the "env" secrets in the container."""
@@ -307,7 +401,7 @@ def build_interactive_jupyter_deployment_k8s_objects(
     # modified by the root group users.
     deployment_builder.add_environment_variable("NB_UMASK", REANA_WORKFLOW_UMASK)
     deployment_builder.add_environment_variable("REANA_WORKSPACE", workspace)
-    deployment_builder.add_run_with_root_permissions()
+    deployment_builder.add_run_with_runtime_user_permissions()
     return deployment_builder.get_deployment_objects()
 
 

--- a/reana_workflow_controller/workflow_run_manager.py
+++ b/reana_workflow_controller/workflow_run_manager.py
@@ -19,6 +19,8 @@ from kubernetes.client.models.v1_delete_options import V1DeleteOptions
 from kubernetes.client.rest import ApiException
 from reana_commons.config import (
     K8S_CERN_EOS_AVAILABLE,
+    K8S_USE_SECURITY_CONTEXT,
+    WORKFLOW_RUNTIME_GROUP_NAME,
     REANA_COMPONENT_NAMING_SCHEME,
     REANA_COMPONENT_PREFIX,
     REANA_INFRASTRUCTURE_KUBERNETES_NAMESPACE,
@@ -30,14 +32,12 @@ from reana_commons.config import (
     REANA_RUNTIME_JOBS_KUBERNETES_NODE_LABEL,
     REANA_RUNTIME_KUBERNETES_SERVICEACCOUNT_NAME,
     REANA_STORAGE_BACKEND,
-    WORKFLOW_RUNTIME_GROUP_NAME,
     WORKFLOW_RUNTIME_USER_GID,
     WORKFLOW_RUNTIME_USER_NAME,
     WORKFLOW_RUNTIME_USER_UID,
     WORKSPACE_PATHS,
 )
 from reana_commons.k8s.api_client import current_k8s_batchv1_api_client
-from reana_commons.k8s.kerberos import get_kerberos_k8s_config
 from reana_commons.k8s.secrets import UserSecretsStore
 from reana_commons.k8s.volumes import (
     create_cvmfs_persistent_volume_claim,
@@ -63,6 +63,7 @@ from reana_workflow_controller.k8s import (
     build_interactive_k8s_objects,
     delete_k8s_ingress_object,
     delete_k8s_objects_if_exist,
+    get_compatible_kerberos_k8s_config,
     instantiate_chained_k8s_objects,
 )
 
@@ -87,6 +88,7 @@ from reana_workflow_controller.config import (  # isort:skip
     REANA_KUBERNETES_JOBS_MAX_USER_MEMORY_LIMIT,
     REANA_KUBERNETES_JOBS_MAX_USER_TIMEOUT_LIMIT,
     REANA_KUBERNETES_JOBS_MIN_USER_UID,
+    REANA_RUNTIME_FS_GROUP_CHANGE_POLICY,
     REANA_WORKFLOW_ENGINE_IMAGE_CWL,
     REANA_WORKFLOW_ENGINE_IMAGE_SERIAL,
     REANA_WORKFLOW_ENGINE_IMAGE_SNAKEMAKE,
@@ -103,6 +105,41 @@ from reana_workflow_controller.config import (  # isort:skip
     KUEUE_ENABLED,
     KUEUE_LOCAL_QUEUE_NAME,
 )
+
+NSS_WRAPPER_VOLUME_NAME = "nss-wrapper"
+NSS_WRAPPER_MOUNT_PATH = "/var/run/nss_wrapper"
+NSS_WRAPPER_PASSWD_PATH = f"{NSS_WRAPPER_MOUNT_PATH}/passwd"
+NSS_WRAPPER_GROUP_PATH = f"{NSS_WRAPPER_MOUNT_PATH}/group"
+LOGGER = logging.getLogger(__name__)
+
+
+def _restricted_security_context(uid: int, gid: int) -> client.V1SecurityContext:
+    """Return a PSA-restricted container security context."""
+    return client.V1SecurityContext(
+        run_as_group=int(gid),
+        run_as_user=int(uid),
+        run_as_non_root=True,
+        allow_privilege_escalation=False,
+        capabilities=client.V1Capabilities(drop=["ALL"]),
+        seccomp_profile=client.V1SeccompProfile(type="RuntimeDefault"),
+    )
+
+
+def _filter_job_controller_env_var_collisions(existing_env_vars, additional_env_vars):
+    """Drop operator-supplied env vars that collide with controller-managed ones."""
+    authoritative_names = {env_var["name"] for env_var in existing_env_vars}
+    filtered_env_vars = []
+    for env_var in additional_env_vars:
+        env_name = env_var["name"]
+        if env_name in authoritative_names:
+            LOGGER.warning(
+                "Ignoring operator-supplied job-controller env var %s because "
+                "the workflow-controller-managed value is authoritative.",
+                env_name,
+            )
+            continue
+        filtered_env_vars.append(env_var)
+    return filtered_env_vars
 
 
 def _container_image_aliases(
@@ -653,7 +690,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         user_secrets = UserSecretsStore.fetch(owner_id)
         kerberos = None
         if self.requires_kerberos():
-            kerberos = get_kerberos_k8s_config(
+            kerberos = get_compatible_kerberos_k8s_config(
                 user_secrets,
                 kubernetes_uid=WORKFLOW_RUNTIME_USER_UID,
             )
@@ -702,12 +739,11 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
             ]
         )
         workflow_engine_container.env.extend(workflow_engine_env_vars)
-        workflow_engine_container.security_context = client.V1SecurityContext(
-            run_as_group=WORKFLOW_RUNTIME_USER_GID,
-            run_as_user=WORKFLOW_RUNTIME_USER_UID,
-            run_as_non_root=True,
-            allow_privilege_escalation=False,
-        )
+        if K8S_USE_SECURITY_CONTEXT:
+            workflow_engine_container.security_context = _restricted_security_context(
+                WORKFLOW_RUNTIME_USER_UID,
+                WORKFLOW_RUNTIME_USER_GID,
+            )
         workflow_engine_container.volume_mounts = [workspace_mount]
 
         if kerberos:
@@ -726,7 +762,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
             env=[],
             volume_mounts=[],
             command=["/bin/bash", "-c"],
-            args=self._create_job_controller_startup_cmd(user),
+            args=self._create_job_controller_startup_cmd(),
             ports=[],
             # Make sure that all the jobs are stopped before the deletion of the run-batch pod
             lifecycle=client.V1Lifecycle(
@@ -738,13 +774,30 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                 )
             ),
         )
+        if K8S_USE_SECURITY_CONTEXT:
+            job_controller_container.security_context = _restricted_security_context(
+                WORKFLOW_RUNTIME_USER_UID,
+                WORKFLOW_RUNTIME_USER_GID,
+            )
 
         job_controller_container.env.extend(
             [
                 {"name": "REANA_USER_ID", "value": owner_id},
                 {"name": "CERN_USER", "value": user},
                 {"name": "USER", "value": user},  # Required by HTCondor
+                {
+                    "name": "K8S_USE_SECURITY_CONTEXT",
+                    "value": str(K8S_USE_SECURITY_CONTEXT),
+                },
                 {"name": "K8S_CERN_EOS_AVAILABLE", "value": K8S_CERN_EOS_AVAILABLE},
+                {
+                    "name": "NSS_WRAPPER_GROUP",
+                    "value": NSS_WRAPPER_GROUP_PATH,
+                },
+                {
+                    "name": "NSS_WRAPPER_PASSWD",
+                    "value": NSS_WRAPPER_PASSWD_PATH,
+                },
                 {"name": "IMAGE_PULL_SECRETS", "value": ",".join(IMAGE_PULL_SECRETS)},
                 {"name": "KUEUE_ENABLED", "value": str(KUEUE_ENABLED)},
                 {
@@ -766,6 +819,22 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                 {
                     "name": "REANA_RUNTIME_KUBERNETES_NAMESPACE",
                     "value": REANA_RUNTIME_KUBERNETES_NAMESPACE,
+                },
+                {
+                    "name": "WORKFLOW_RUNTIME_GROUP_NAME",
+                    "value": WORKFLOW_RUNTIME_GROUP_NAME,
+                },
+                {
+                    "name": "WORKFLOW_RUNTIME_USER_GID",
+                    "value": str(WORKFLOW_RUNTIME_USER_GID),
+                },
+                {
+                    "name": "WORKFLOW_RUNTIME_USER_NAME",
+                    "value": WORKFLOW_RUNTIME_USER_NAME,
+                },
+                {
+                    "name": "WORKFLOW_RUNTIME_USER_UID",
+                    "value": str(WORKFLOW_RUNTIME_USER_UID),
                 },
                 {
                     "name": "REANA_JOB_HOSTPATH_MOUNTS",
@@ -827,9 +896,12 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
                     "value": REANA_KUBERNETES_JOBS_MIN_USER_UID,
                 },
             )
-        # env vars coming from Helm values are added after the ones from r-w-controller
-        # so that the former can override the latter in case of necessity
-        job_controller_container.env.extend(copy.deepcopy(JOB_CONTROLLER_ENV_VARS))
+        job_controller_container.env.extend(
+            _filter_job_controller_env_var_collisions(
+                job_controller_container.env,
+                copy.deepcopy(JOB_CONTROLLER_ENV_VARS),
+            )
+        )
         job_controller_container.env.extend(job_controller_env_secrets)
         if REANA_RUNTIME_JOBS_KUBERNETES_NODE_LABEL:
             job_controller_container.env.append(
@@ -859,16 +931,24 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
             workspace_mount,
             secrets_volume_mount,
             uwsgi_config_mount,
+            {"name": NSS_WRAPPER_VOLUME_NAME, "mountPath": NSS_WRAPPER_MOUNT_PATH},
         ]
 
         job_controller_container.ports = [
             {"containerPort": current_app.config["JOB_CONTROLLER_CONTAINER_PORT"]}
         ]
         containers = [workflow_engine_container, job_controller_container]
+        pod_security_context = None
+        if K8S_USE_SECURITY_CONTEXT:
+            pod_security_context = client.V1PodSecurityContext(
+                fs_group=int(WORKFLOW_RUNTIME_USER_GID),
+                fs_group_change_policy=REANA_RUNTIME_FS_GROUP_CHANGE_POLICY,
+            )
         spec.template.spec = client.V1PodSpec(
             containers=containers,
             node_selector=REANA_RUNTIME_BATCH_KUBERNETES_NODE_LABEL,
             init_containers=[],
+            security_context=pod_security_context,
             termination_grace_period_seconds=REANA_RUNTIME_BATCH_TERMINATION_GRACE_PERIOD,
         )
         spec.template.spec.service_account_name = (
@@ -883,6 +963,7 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         }
         volumes = [
             workspace_volume,
+            {"name": NSS_WRAPPER_VOLUME_NAME, "emptyDir": {}},
             user_secrets.get_file_secrets_volume_as_k8s_specs(),
             uwsgi_config_volume,
         ]
@@ -923,28 +1004,11 @@ class KubernetesWorkflowRunManager(WorkflowRunManager):
         job.spec.backoff_limit = 0
         return job
 
-    def _create_job_controller_startup_cmd(self, user=None):
-        """Create job controller startup cmd."""
-        if os.getenv("FLASK_DEBUG", "").lower() in ("1", "true"):
-            base_cmd = "exec flask run -h 0.0.0.0;"
-        else:
-            base_cmd = "exec uwsgi --ini /var/reana/uwsgi/uwsgi.ini;"
+    def _create_job_controller_startup_cmd(self):
+        """Create rootless job controller startup command.
 
-        if user:
-            add_group_cmd = (
-                "getent group '{gid}' || groupadd -f -g '{gid}' '{name}';".format(
-                    gid=WORKFLOW_RUNTIME_USER_GID, name=WORKFLOW_RUNTIME_GROUP_NAME
-                )
-            )
-            add_user_cmd = "useradd -u {} -g {} -M {};".format(
-                WORKFLOW_RUNTIME_USER_UID, WORKFLOW_RUNTIME_USER_GID, user
-            )
-            chown_workspace_cmd = "chown -R {} {};".format(
-                WORKFLOW_RUNTIME_USER_UID,
-                self.workflow.workspace_path,
-            )
-            run_app_cmd = 'exec su {} /bin/bash -c "{}"'.format(user, base_cmd)
-            full_cmd = add_group_cmd + add_user_cmd + chown_workspace_cmd + run_app_cmd
-            return [full_cmd]
-        else:
-            return base_cmd.split()
+        Shared workspaces are expected to stay writable via the common GID=0
+        contract and group-writable workspace creation umask, so no recursive
+        workspace chown is needed here.
+        """
+        return ["exec python3 -m reana_job_controller.nss_wrapper"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,3 +62,86 @@ def test_force_garbage_collection_accepts_valid_values(monkeypatch):
         ]
 
     _reload_config()
+
+
+def test_runtime_fs_group_change_policy_defaults_to_on_root_mismatch(monkeypatch):
+    """Test runtime fsGroup change policy defaults to OnRootMismatch."""
+    with monkeypatch.context() as m:
+        m.delenv("REANA_RUNTIME_FS_GROUP_CHANGE_POLICY", raising=False)
+        reloaded_config = _reload_config()
+        assert reloaded_config.REANA_RUNTIME_FS_GROUP_CHANGE_POLICY == "OnRootMismatch"
+
+    _reload_config()
+
+
+def test_runtime_fs_group_change_policy_accepts_always(monkeypatch):
+    """Test runtime fsGroup change policy accepts supported values."""
+    with monkeypatch.context() as m:
+        m.setenv("REANA_RUNTIME_FS_GROUP_CHANGE_POLICY", "Always")
+        reloaded_config = _reload_config()
+        assert reloaded_config.REANA_RUNTIME_FS_GROUP_CHANGE_POLICY == "Always"
+
+    _reload_config()
+
+
+def test_runtime_fs_group_change_policy_rejects_invalid_value(monkeypatch):
+    """Test runtime fsGroup change policy rejects unsupported values."""
+    with monkeypatch.context() as m:
+        m.setenv("REANA_RUNTIME_FS_GROUP_CHANGE_POLICY", "Never")
+        with pytest.raises(ValueError) as exc_info:
+            _reload_config()
+        assert (
+            str(exc_info.value)
+            == "Invalid REANA_RUNTIME_FS_GROUP_CHANGE_POLICY value: Never. "
+            "Valid values: Always, OnRootMismatch"
+        )
+
+    _reload_config()
+
+
+def test_runtime_sessions_supplemental_groups_defaults_to_users_gid(monkeypatch):
+    """Test session supplemental groups default to the Jupyter users group."""
+    with monkeypatch.context() as m:
+        m.delenv("REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS", raising=False)
+        reloaded_config = _reload_config()
+        assert reloaded_config.REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS == [100]
+
+    _reload_config()
+
+
+def test_runtime_sessions_supplemental_groups_accepts_empty_string(monkeypatch):
+    """Test empty supplemental groups omit the pod supplementalGroups field."""
+    with monkeypatch.context() as m:
+        m.setenv("REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS", "")
+        reloaded_config = _reload_config()
+        assert reloaded_config.REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS == []
+
+    _reload_config()
+
+
+def test_runtime_sessions_supplemental_groups_parses_integers(monkeypatch):
+    """Test runtime session supplemental groups parse comma-separated integers."""
+    with monkeypatch.context() as m:
+        m.setenv("REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS", "100, 2000,")
+        reloaded_config = _reload_config()
+        assert reloaded_config.REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS == [
+            100,
+            2000,
+        ]
+
+    _reload_config()
+
+
+def test_runtime_sessions_supplemental_groups_reject_invalid_values(monkeypatch):
+    """Test runtime session supplemental groups reject invalid values."""
+    with monkeypatch.context() as m:
+        m.setenv("REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS", "100,abc")
+        with pytest.raises(ValueError) as exc_info:
+            _reload_config()
+        assert (
+            str(exc_info.value)
+            == "Invalid REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS value: abc. "
+            "Values must be non-negative integers."
+        )
+
+    _reload_config()

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -10,7 +10,8 @@ from uuid import uuid4
 from flask import current_app
 from mock import patch, MagicMock
 
-
+from reana_commons.config import WORKFLOW_RUNTIME_USER_GID, WORKFLOW_RUNTIME_USER_UID
+from reana_workflow_controller.config import REANA_RUNTIME_FS_GROUP_CHANGE_POLICY
 from reana_workflow_controller.dask import requires_dask
 
 
@@ -314,7 +315,7 @@ def test_add_shared_volume_already_added(dask_resource_manager):
 def test_add_krb5_containers(dask_resource_manager):
     """Test _add_krb5_containers method."""
     with patch(
-        "reana_workflow_controller.dask.get_kerberos_k8s_config"
+        "reana_workflow_controller.dask.get_compatible_kerberos_k8s_config"
     ) as mock_get_krb5_config, patch(
         "reana_workflow_controller.dask.KRB5_STATUS_FILE_LOCATION", "/tmp/krb5_status"
     ):
@@ -462,6 +463,40 @@ def test_prepare_cluster(dask_resource_manager):
             ][0]["image"]
             == dask_resource_manager.cluster_image
         )
+        assert dask_resource_manager.cluster_body["spec"]["scheduler"]["spec"][
+            "securityContext"
+        ] == {
+            "fsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+            "fsGroupChangePolicy": REANA_RUNTIME_FS_GROUP_CHANGE_POLICY,
+            "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+            "runAsUser": int(WORKFLOW_RUNTIME_USER_UID),
+            "runAsNonRoot": True,
+        }
+        assert dask_resource_manager.cluster_body["spec"]["worker"]["spec"][
+            "securityContext"
+        ] == {
+            "fsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+            "fsGroupChangePolicy": REANA_RUNTIME_FS_GROUP_CHANGE_POLICY,
+            "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+            "runAsUser": int(WORKFLOW_RUNTIME_USER_UID),
+            "runAsNonRoot": True,
+        }
+        assert dask_resource_manager.cluster_body["spec"]["scheduler"]["spec"][
+            "containers"
+        ][0]["securityContext"] == {
+            "runAsNonRoot": True,
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+            "seccompProfile": {"type": "RuntimeDefault"},
+        }
+        assert dask_resource_manager.cluster_body["spec"]["worker"]["spec"][
+            "containers"
+        ][0]["securityContext"] == {
+            "runAsNonRoot": True,
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+            "seccompProfile": {"type": "RuntimeDefault"},
+        }
 
         assert (
             dask_resource_manager.secrets_volume_mount
@@ -478,4 +513,60 @@ def test_prepare_cluster(dask_resource_manager):
                 "selector"
             ]["dask.org/cluster-name"]
             == dask_resource_manager.cluster_name
+        )
+
+
+def test_prepare_cluster_skips_security_context_when_disabled(dask_resource_manager):
+    """Test _prepare_cluster omits explicit security contexts when disabled."""
+    with patch.object(dask_resource_manager, "_add_image_pull_secrets"), patch.object(
+        dask_resource_manager, "_add_hostpath_volumes"
+    ), patch.object(dask_resource_manager, "_add_workspace_volume"), patch.object(
+        dask_resource_manager, "_add_shared_volume"
+    ), patch.object(
+        dask_resource_manager, "_add_eos_volume"
+    ), patch.object(
+        dask_resource_manager.secrets_store, "get_file_secrets_volume_as_k8s_specs"
+    ) as mock_get_file_secrets_volume, patch(
+        "reana_workflow_controller.dask.K8S_USE_SECURITY_CONTEXT", False
+    ):
+        mock_get_file_secrets_volume.return_value = {"name": "secrets-volume"}
+        dask_resource_manager.cluster_body = {
+            "spec": {
+                "worker": {
+                    "spec": {
+                        "containers": [
+                            {"args": ["worker-command"], "env": [], "volumeMounts": []}
+                        ],
+                        "volumes": [],
+                    }
+                },
+                "scheduler": {
+                    "spec": {"containers": [{}]},
+                    "service": {"selector": {}},
+                },
+            }
+        }
+        dask_resource_manager.autoscaler_body = {"spec": {}}
+
+        dask_resource_manager._prepare_cluster()
+
+        assert (
+            "securityContext"
+            not in dask_resource_manager.cluster_body["spec"]["scheduler"]["spec"]
+        )
+        assert (
+            "securityContext"
+            not in dask_resource_manager.cluster_body["spec"]["worker"]["spec"]
+        )
+        assert (
+            "securityContext"
+            not in dask_resource_manager.cluster_body["spec"]["scheduler"]["spec"][
+                "containers"
+            ][0]
+        )
+        assert (
+            "securityContext"
+            not in dask_resource_manager.cluster_body["spec"]["worker"]["spec"][
+                "containers"
+            ][0]
         )

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -4,10 +4,19 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
-from reana_workflow_controller.k8s import InteractiveDeploymentK8sBuilder
+from reana_commons.config import WORKFLOW_RUNTIME_USER_GID, WORKFLOW_RUNTIME_USER_UID
+from reana_workflow_controller.config import (
+    REANA_RUNTIME_FS_GROUP_CHANGE_POLICY,
+    REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS,
+)
+from reana_workflow_controller.k8s import (
+    InteractiveDeploymentK8sBuilder,
+    get_compatible_kerberos_k8s_config,
+)
 from reana_commons.k8s.secrets import UserSecretsStore, UserSecrets, Secret
 
 
@@ -34,7 +43,7 @@ def test_interactive_deployment_k8s_builder_user_secrets(monkeypatch):
     builder.add_user_secrets()
     builder.add_environment_variable("first_env", "1")
     builder.add_environment_variable("second_env", "2")
-    builder.add_run_with_root_permissions()
+    builder.add_run_with_runtime_user_permissions()
     objs = builder.get_deployment_objects()
 
     deployment = objs["deployment"]
@@ -43,3 +52,131 @@ def test_interactive_deployment_k8s_builder_user_secrets(monkeypatch):
     assert any(v["name"] == "k8s-secret" for v in pod.volumes)
     assert any(vm["name"] == "k8s-secret" for vm in pod.containers[0].volume_mounts)
     assert any(e["name"] == "third_env" for e in pod.containers[0].env)
+    assert pod.security_context.fs_group == int(WORKFLOW_RUNTIME_USER_GID)
+    assert (
+        pod.security_context.fs_group_change_policy
+        == REANA_RUNTIME_FS_GROUP_CHANGE_POLICY
+    )
+    assert (
+        pod.security_context.supplemental_groups
+        == REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS
+    )
+    assert pod.containers[0].security_context.run_as_user == int(
+        WORKFLOW_RUNTIME_USER_UID
+    )
+    assert pod.containers[0].security_context.run_as_group == int(
+        WORKFLOW_RUNTIME_USER_GID
+    )
+    assert pod.containers[0].security_context.run_as_non_root is True
+    assert pod.containers[0].security_context.allow_privilege_escalation is False
+    assert pod.containers[0].security_context.capabilities.drop == ["ALL"]
+    assert pod.containers[0].security_context.seccomp_profile.type == "RuntimeDefault"
+
+
+def test_interactive_deployment_k8s_builder_skips_security_context_when_disabled(
+    monkeypatch,
+):
+    """Do not force interactive-session UID/GID when disabled."""
+    monkeypatch.setattr("reana_workflow_controller.k8s.K8S_USE_SECURITY_CONTEXT", False)
+
+    builder = InteractiveDeploymentK8sBuilder(
+        "name", "workflow_id", "owner_id", "workspace", "docker_image", "port", "path"
+    )
+
+    builder.add_run_with_runtime_user_permissions()
+
+    assert (
+        builder.get_deployment_objects()[
+            "deployment"
+        ].spec.template.spec.security_context
+        is None
+    )
+    assert (
+        builder.get_deployment_objects()["deployment"]
+        .spec.template.spec.containers[0]
+        .security_context
+        is None
+    )
+
+
+def test_interactive_deployment_k8s_builder_omits_empty_supplemental_groups(
+    monkeypatch,
+):
+    """Do not serialise supplementalGroups when the config is empty."""
+    monkeypatch.setattr(
+        "reana_workflow_controller.k8s.REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS",
+        [],
+    )
+
+    builder = InteractiveDeploymentK8sBuilder(
+        "name", "workflow_id", "owner_id", "workspace", "docker_image", "port", "path"
+    )
+
+    assert builder.get_deployment_objects()[
+        "deployment"
+    ].spec.template.spec.security_context.supplemental_groups in (None, [])
+
+
+def test_get_compatible_kerberos_k8s_config_supports_old_commons_api(monkeypatch):
+    """Retry Kerberos config calls without the new optional kwarg when needed."""
+    calls = []
+
+    def old_get_kerberos_k8s_config(user_secrets, kubernetes_uid):
+        calls.append((user_secrets, kubernetes_uid))
+        return "kerberos-config"
+
+    monkeypatch.setattr(
+        "reana_workflow_controller.k8s.get_kerberos_k8s_config",
+        old_get_kerberos_k8s_config,
+    )
+
+    kerberos_config = get_compatible_kerberos_k8s_config("secrets", 1000)
+
+    assert kerberos_config == "kerberos-config"
+    assert calls == [("secrets", 1000)]
+
+
+def test_get_compatible_kerberos_k8s_config_backfills_partial_security_context(
+    monkeypatch,
+):
+    """Backfill missing PSA fields from released commons Kerberos specs."""
+
+    def partially_hardened_get_kerberos_k8s_config(
+        user_secrets, kubernetes_uid, use_security_context=True
+    ):
+        return SimpleNamespace(
+            init_container={
+                "securityContext": {
+                    "runAsUser": int(kubernetes_uid),
+                    "runAsNonRoot": True,
+                }
+            },
+            renew_container={
+                "securityContext": {
+                    "runAsUser": int(kubernetes_uid),
+                    "runAsNonRoot": True,
+                }
+            },
+        )
+
+    monkeypatch.setattr(
+        "reana_workflow_controller.k8s.get_kerberos_k8s_config",
+        partially_hardened_get_kerberos_k8s_config,
+    )
+
+    kerberos_config = get_compatible_kerberos_k8s_config("secrets", 1000)
+
+    expected_security_context = {
+        "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+        "runAsUser": int(WORKFLOW_RUNTIME_USER_UID),
+        "runAsNonRoot": True,
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+    assert (
+        kerberos_config.init_container["securityContext"] == expected_security_context
+    )
+    assert (
+        kerberos_config.renew_container["securityContext"] == expected_security_context
+    )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,6 +17,7 @@ import fs
 import mock
 import pytest
 from flask import url_for
+from reana_commons.config import WORKFLOW_RUNTIME_USER_GID, WORKFLOW_RUNTIME_USER_UID
 from reana_db.database import Session
 from reana_db.models import (
     InteractiveSession,
@@ -25,6 +26,10 @@ from reana_db.models import (
     RunStatus,
     Workflow,
     UserWorkflow,
+)
+from reana_workflow_controller.config import (
+    REANA_RUNTIME_FS_GROUP_CHANGE_POLICY,
+    REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS,
 )
 from reana_workflow_controller.rest.utils import (
     create_workflow_workspace,
@@ -1870,7 +1875,7 @@ def test_create_interactive_session(
             current_k8s_networking_api_client=mock.DEFAULT,
             current_k8s_appsv1_api_client=mock.DEFAULT,
             UserSecretsStore=mock.DEFAULT,
-        ):
+        ) as mocks:
             res = client.post(
                 url_for(
                     "workflows_session.open_interactive_session",
@@ -1880,6 +1885,69 @@ def test_create_interactive_session(
                 query_string={"user": user0.id_},
             )
             assert res.json == expected_data
+            deployment = mocks[
+                "current_k8s_appsv1_api_client"
+            ].create_namespaced_deployment.call_args[0][1]
+            pod = deployment.spec.template.spec
+            container = pod.containers[0]
+
+            assert pod.security_context.fs_group == int(WORKFLOW_RUNTIME_USER_GID)
+            assert (
+                pod.security_context.fs_group_change_policy
+                == REANA_RUNTIME_FS_GROUP_CHANGE_POLICY
+            )
+            assert (
+                pod.security_context.supplemental_groups
+                == REANA_RUNTIME_SESSIONS_SUPPLEMENTAL_GROUPS
+            )
+            assert container.security_context.run_as_user == int(
+                WORKFLOW_RUNTIME_USER_UID
+            )
+            assert container.security_context.run_as_group == int(
+                WORKFLOW_RUNTIME_USER_GID
+            )
+            assert container.security_context.run_as_non_root is True
+            assert container.security_context.allow_privilege_escalation is False
+            assert container.security_context.capabilities.drop == ["ALL"]
+            assert container.security_context.seccomp_profile.type == "RuntimeDefault"
+
+
+def test_create_interactive_session_skips_security_context_when_disabled(
+    app,
+    user0,
+    sample_serial_workflow_in_db,
+    interactive_session_environments,
+    monkeypatch,
+):
+    """Test create interactive session without explicit security contexts."""
+    wrm = WorkflowRunManager(sample_serial_workflow_in_db)
+    expected_data = {"path": wrm._generate_interactive_workflow_path()}
+    monkeypatch.setattr("reana_workflow_controller.k8s.K8S_USE_SECURITY_CONTEXT", False)
+
+    with app.test_client() as client:
+        with mock.patch.multiple(
+            "reana_workflow_controller.k8s",
+            current_k8s_corev1_api_client=mock.DEFAULT,
+            current_k8s_networking_api_client=mock.DEFAULT,
+            current_k8s_appsv1_api_client=mock.DEFAULT,
+            UserSecretsStore=mock.DEFAULT,
+        ) as mocks:
+            res = client.post(
+                url_for(
+                    "workflows_session.open_interactive_session",
+                    workflow_id_or_name=sample_serial_workflow_in_db.id_,
+                    interactive_session_type="jupyter",
+                ),
+                query_string={"user": user0.id_},
+            )
+            assert res.json == expected_data
+            deployment = mocks[
+                "current_k8s_appsv1_api_client"
+            ].create_namespaced_deployment.call_args[0][1]
+            pod = deployment.spec.template.spec
+
+            assert pod.security_context is None
+            assert pod.containers[0].security_context is None
 
 
 def test_create_interactive_session_unknown_type(

--- a/tests/test_workflow_run_manager.py
+++ b/tests/test_workflow_run_manager.py
@@ -14,7 +14,12 @@ import pytest
 from kubernetes.client.rest import ApiException
 from mock import DEFAULT, Mock, patch
 
-from reana_commons.config import KRB5_INIT_CONTAINER_NAME
+from reana_commons.config import (
+    KRB5_INIT_CONTAINER_NAME,
+    KRB5_RENEW_CONTAINER_NAME,
+    WORKFLOW_RUNTIME_USER_GID,
+    WORKFLOW_RUNTIME_USER_UID,
+)
 from reana_db.database import Session
 from reana_db.models import (
     RunStatus,
@@ -24,6 +29,7 @@ from reana_db.models import (
 
 from reana_workflow_controller.config import (
     REANA_INTERACTIVE_SESSIONS_ENVIRONMENTS,
+    REANA_RUNTIME_FS_GROUP_CHANGE_POLICY,
 )
 from reana_workflow_controller.errors import REANAInteractiveSessionError
 from reana_workflow_controller.workflow_run_manager import (
@@ -259,9 +265,161 @@ def test_create_job_spec_kerberos(
     init_containers = job.spec.template.spec.init_containers
     assert len(init_containers) == 1
     assert init_containers[0]["name"] == KRB5_INIT_CONTAINER_NAME
+    assert init_containers[0]["securityContext"] == {
+        "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+        "runAsUser": int(WORKFLOW_RUNTIME_USER_UID),
+        "runAsNonRoot": True,
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+
+    renew_container = job.spec.template.spec.containers[-1]
+    assert renew_container["name"] == KRB5_RENEW_CONTAINER_NAME
+    assert renew_container["securityContext"] == {
+        "runAsGroup": int(WORKFLOW_RUNTIME_USER_GID),
+        "runAsUser": int(WORKFLOW_RUNTIME_USER_UID),
+        "runAsNonRoot": True,
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
 
     volumes = [volume["name"] for volume in job.spec.template.spec.volumes]
     assert len(set(volumes)) == len(volumes)  # volumes have unique names
     assert any(volume.startswith("reana-secretsstore") for volume in volumes)
     assert "krb5-cache" in volumes
     assert "krb5-conf" in volumes
+
+
+def test_create_job_spec_job_controller_runs_as_runtime_user(
+    sample_serial_workflow_in_db,
+    mock_user_secrets,
+):
+    """Test that run-batch containers run as the default non-root REANA user."""
+    kwrm = KubernetesWorkflowRunManager(sample_serial_workflow_in_db)
+    job = kwrm._create_job_spec("run-batch-test")
+
+    workflow_engine, job_controller = job.spec.template.spec.containers
+    volumes = {volume["name"]: volume for volume in job.spec.template.spec.volumes}
+    env_vars = {
+        env["name"]: env["value"] for env in job_controller.env if "value" in env
+    }
+    volume_mounts = {
+        volume_mount["name"]: volume_mount["mountPath"]
+        for volume_mount in job_controller.volume_mounts
+    }
+
+    assert job.spec.template.spec.security_context.fs_group == int(
+        WORKFLOW_RUNTIME_USER_GID
+    )
+    assert (
+        job.spec.template.spec.security_context.fs_group_change_policy
+        == REANA_RUNTIME_FS_GROUP_CHANGE_POLICY
+    )
+    assert workflow_engine.security_context.run_as_user == int(
+        WORKFLOW_RUNTIME_USER_UID
+    )
+    assert workflow_engine.security_context.run_as_group == int(
+        WORKFLOW_RUNTIME_USER_GID
+    )
+    assert workflow_engine.security_context.run_as_non_root is True
+    assert workflow_engine.security_context.allow_privilege_escalation is False
+    assert workflow_engine.security_context.capabilities.drop == ["ALL"]
+    assert workflow_engine.security_context.seccomp_profile.type == "RuntimeDefault"
+    assert job_controller.security_context.run_as_user == int(WORKFLOW_RUNTIME_USER_UID)
+    assert job_controller.security_context.run_as_group == int(
+        WORKFLOW_RUNTIME_USER_GID
+    )
+    assert job_controller.security_context.run_as_non_root is True
+    assert job_controller.security_context.allow_privilege_escalation is False
+    assert job_controller.security_context.capabilities.drop == ["ALL"]
+    assert job_controller.security_context.seccomp_profile.type == "RuntimeDefault"
+    assert job_controller.args == ["exec python3 -m reana_job_controller.nss_wrapper"]
+    assert env_vars["USER"] == "reana"
+    assert env_vars["CERN_USER"] == "reana"
+    assert env_vars["K8S_USE_SECURITY_CONTEXT"] == "True"
+    assert env_vars["NSS_WRAPPER_PASSWD"] == "/var/run/nss_wrapper/passwd"
+    assert env_vars["NSS_WRAPPER_GROUP"] == "/var/run/nss_wrapper/group"
+    assert env_vars["WORKFLOW_RUNTIME_USER_UID"] == str(WORKFLOW_RUNTIME_USER_UID)
+    assert env_vars["WORKFLOW_RUNTIME_USER_GID"] == str(WORKFLOW_RUNTIME_USER_GID)
+    assert env_vars["WORKFLOW_RUNTIME_USER_NAME"] == "reana"
+    assert env_vars["WORKFLOW_RUNTIME_GROUP_NAME"] == "root"
+    assert "nss-wrapper" in volumes
+    assert volumes["nss-wrapper"]["emptyDir"] == {}
+    assert "uwsgi-config-reana-job-controller" in volumes
+    assert volume_mounts["nss-wrapper"] == "/var/run/nss_wrapper"
+    assert volume_mounts["uwsgi-config-reana-job-controller"] == "/var/reana/uwsgi"
+
+
+def test_create_job_spec_skips_security_context_when_disabled(
+    sample_serial_workflow_in_db, mock_user_secrets, monkeypatch
+):
+    """Test that OpenShift-style deployments can disable explicit security contexts."""
+    monkeypatch.setattr(
+        "reana_workflow_controller.workflow_run_manager.K8S_USE_SECURITY_CONTEXT",
+        False,
+    )
+    kwrm = KubernetesWorkflowRunManager(sample_serial_workflow_in_db)
+    job = kwrm._create_job_spec("run-batch-test")
+
+    workflow_engine, job_controller = job.spec.template.spec.containers
+    env_vars = {
+        env["name"]: env["value"] for env in job_controller.env if "value" in env
+    }
+    volume_mounts = {
+        volume_mount["name"]: volume_mount["mountPath"]
+        for volume_mount in job_controller.volume_mounts
+    }
+    volumes = {volume["name"]: volume for volume in job.spec.template.spec.volumes}
+
+    assert job.spec.template.spec.security_context is None
+    assert workflow_engine.security_context is None
+    assert job_controller.security_context is None
+    assert env_vars["USER"] == "reana"
+    assert env_vars["CERN_USER"] == "reana"
+    assert env_vars["K8S_USE_SECURITY_CONTEXT"] == "False"
+    assert env_vars["NSS_WRAPPER_PASSWD"] == "/var/run/nss_wrapper/passwd"
+    assert env_vars["NSS_WRAPPER_GROUP"] == "/var/run/nss_wrapper/group"
+    assert "nss-wrapper" in volumes
+    assert "uwsgi-config-reana-job-controller" in volumes
+    assert volume_mounts["nss-wrapper"] == "/var/run/nss_wrapper"
+    assert volume_mounts["uwsgi-config-reana-job-controller"] == "/var/reana/uwsgi"
+
+
+def test_create_job_spec_drops_colliding_job_controller_env_vars(
+    sample_serial_workflow_in_db, mock_user_secrets, monkeypatch, caplog
+):
+    """Test that Helm passthrough env vars cannot override controller-managed ones."""
+    monkeypatch.setattr(
+        "reana_workflow_controller.workflow_run_manager.JOB_CONTROLLER_ENV_VARS",
+        [
+            {"name": "WORKFLOW_RUNTIME_USER_UID", "value": "4321"},
+            {"name": "NSS_WRAPPER_PASSWD", "value": "/tmp/custom-passwd"},
+            {"name": "EXTRA_OPERATOR_VAR", "value": "ok"},
+            {"name": "workflow_runtime_user_uid", "value": "case-sensitive"},
+        ],
+    )
+    caplog.set_level("WARNING")
+
+    kwrm = KubernetesWorkflowRunManager(sample_serial_workflow_in_db)
+    job = kwrm._create_job_spec("run-batch-test")
+
+    _, job_controller = job.spec.template.spec.containers
+    env_names = [env["name"] for env in job_controller.env]
+    env_vars = {
+        env["name"]: env["value"] for env in job_controller.env if "value" in env
+    }
+
+    assert env_names.count("WORKFLOW_RUNTIME_USER_UID") == 1
+    assert env_names.count("NSS_WRAPPER_PASSWD") == 1
+    assert env_vars["WORKFLOW_RUNTIME_USER_UID"] == str(WORKFLOW_RUNTIME_USER_UID)
+    assert env_vars["NSS_WRAPPER_PASSWD"] == "/var/run/nss_wrapper/passwd"
+    assert env_vars["EXTRA_OPERATOR_VAR"] == "ok"
+    assert env_vars["workflow_runtime_user_uid"] == "case-sensitive"
+    warning_messages = [record.getMessage() for record in caplog.records]
+    assert any("WORKFLOW_RUNTIME_USER_UID" in message for message in warning_messages)
+    assert any("NSS_WRAPPER_PASSWD" in message for message in warning_messages)
+    assert not any(
+        "workflow_runtime_user_uid" in message for message in warning_messages
+    )


### PR DESCRIPTION
Run workflow-engine, job-controller, Dask and session pods as the shared runtime user instead of relying on UID 0.

The run-batch startup path now passes the runtime identity expected by the job-controller bootstrap and relies on fsGroup coordination for shared workspace access instead of a root-side workspace chown step.

Interactive sessions also move from root to the fixed runtime user. Session images therefore need to tolerate a non-root entrypoint and the restricted container security context.