### PR TITLE
fix(factory): initialise workspace umask during app startup

### DIFF
--- a/reana_workflow_controller/dask.py
+++ b/reana_workflow_controller/dask.py
@@ -11,7 +11,6 @@ import os
 import yaml
 
 from flask import current_app
-
 from kubernetes import client
 
 from reana_db.database import Session
@@ -23,6 +22,7 @@ from reana_commons.config import (
     K8S_USE_SECURITY_CONTEXT,
     KRB5_STATUS_FILE_LOCATION,
     REANA_JOB_HOSTPATH_MOUNTS,
+    REANA_WORKFLOW_UMASK,
     WORKFLOW_RUNTIME_USER_GID,
     WORKFLOW_RUNTIME_USER_UID,
     REANA_RUNTIME_KUBERNETES_NAMESPACE,
@@ -217,7 +217,7 @@ class DaskResourceManager:
 
         # Create the worker command
         self.cluster_body["spec"]["worker"]["spec"]["containers"][0]["args"] = [
-            f"cd {self.workflow_workspace} && exec dask-worker --name $(DASK_WORKER_NAME) --dashboard --dashboard-address 8788 --nthreads {self.num_of_threads} --memory-limit {self.single_worker_memory}"
+            f"cd {self.workflow_workspace} && umask {REANA_WORKFLOW_UMASK:04o} && exec dask-worker --name $(DASK_WORKER_NAME) --dashboard --dashboard-address 8788 --nthreads {self.num_of_threads} --memory-limit {self.single_worker_memory}"
         ]
 
         # Set resource limits for workers

--- a/reana_workflow_controller/factory.py
+++ b/reana_workflow_controller/factory.py
@@ -11,10 +11,11 @@
 from __future__ import absolute_import
 
 import logging
+import os
 
 from flask import Flask, jsonify
 from marshmallow.exceptions import ValidationError
-from reana_commons.config import REANA_LOG_FORMAT, REANA_LOG_LEVEL
+from reana_commons.config import REANA_LOG_FORMAT, REANA_LOG_LEVEL, REANA_WORKFLOW_UMASK
 from reana_db.database import Session
 from werkzeug.exceptions import UnprocessableEntity
 
@@ -50,6 +51,7 @@ def handle_args_validation_error(error: UnprocessableEntity):
 def create_app(config_mapping=None):
     """REANA Workflow Controller application factory."""
     logging.basicConfig(level=REANA_LOG_LEVEL, format=REANA_LOG_FORMAT)
+    os.umask(REANA_WORKFLOW_UMASK)
     app = Flask(__name__)
     app.config.from_object("reana_workflow_controller.config")
     if config_mapping:

--- a/reana_workflow_controller/rest/utils.py
+++ b/reana_workflow_controller/rest/utils.py
@@ -32,7 +32,7 @@ from flask import jsonify, request, send_file
 from git import Repo
 from kubernetes.client.rest import ApiException
 from reana_commons import workspace
-from reana_commons.config import REANA_WORKFLOW_UMASK, WORKFLOW_TIME_FORMAT
+from reana_commons.config import WORKFLOW_TIME_FORMAT
 from reana_commons.k8s.secrets import UserSecretsStore
 from reana_commons.utils import (
     get_workflow_status_change_verb,
@@ -396,7 +396,6 @@ def create_workflow_workspace(
     :param path: Relative path to workspace directory.
     :return: Absolute workspace path.
     """
-    os.umask(REANA_WORKFLOW_UMASK)
     os.makedirs(path, exist_ok=True)
     if git_url and git_ref:
         user_secrets = UserSecretsStore.fetch(user_id)

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -10,7 +10,12 @@ from uuid import uuid4
 from flask import current_app
 from mock import patch, MagicMock
 
-from reana_commons.config import WORKFLOW_RUNTIME_USER_GID, WORKFLOW_RUNTIME_USER_UID
+from reana_commons.config import (
+    REANA_WORKFLOW_UMASK,
+    WORKFLOW_RUNTIME_USER_GID,
+    WORKFLOW_RUNTIME_USER_UID,
+)
+
 from reana_workflow_controller.config import REANA_RUNTIME_FS_GROUP_CHANGE_POLICY
 from reana_workflow_controller.dask import requires_dask
 
@@ -443,7 +448,7 @@ def test_prepare_cluster(dask_resource_manager):
             "env"
         ]
 
-        expected_command = f"cd {dask_resource_manager.workflow_workspace} && exec dask-worker --name $(DASK_WORKER_NAME) --dashboard --dashboard-address 8788 --nthreads 8 --memory-limit 256Mi"
+        expected_command = f"cd {dask_resource_manager.workflow_workspace} && umask {REANA_WORKFLOW_UMASK:04o} && exec dask-worker --name $(DASK_WORKER_NAME) --dashboard --dashboard-address 8788 --nthreads 8 --memory-limit 256Mi"
         assert (
             dask_resource_manager.cluster_body["spec"]["worker"]["spec"]["containers"][
                 0

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Application factory tests."""
+
+from unittest.mock import patch
+
+from reana_commons.config import REANA_WORKFLOW_UMASK
+
+from reana_workflow_controller.factory import create_app
+
+
+@patch("reana_workflow_controller.factory.os.umask")
+def test_create_app_sets_workflow_umask(mock_umask):
+    """Set the workspace umask once during application initialisation."""
+    create_app({"SECRET_KEY": "test-secret", "TESTING": True})
+
+    mock_umask.assert_called_once_with(REANA_WORKFLOW_UMASK)


### PR DESCRIPTION
Initialise the workspace umask once during controller application startup instead of mutating it from an individual request worker.

Apply the same group-writable umask explicitly in Dask worker shells so all workspace producers use deterministic permissions.

Closes reanahub/reana-workflow-engine-cwl#321